### PR TITLE
Logging workaround + Bump Version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bittensor==6.9.3
+bittensor==6.11.0
 torch==2.0.1
 typer==0.9.0
 starlette==0.27.0

--- a/sturdy/base/neuron.py
+++ b/sturdy/base/neuron.py
@@ -68,6 +68,14 @@ class BaseNeuron(ABC):
         # Set up logging with the provided configuration and directory.
         bt.logging(config=self.config, logging_dir=self.config.full_path)
 
+        # TODO: Surely there's a better way to do this right?
+        # Had to add this because of logging infra changes from bittensor>=6.10.0
+        bt.logging.before_enable_default()
+        if self.config.logging.debug:
+            bt.debug()
+        if self.config.logging.trace:
+            bt.trace()
+
         # If a gpu is required, set the device to cuda:N (e.g. cuda:0)
         self.device = self.config.neuron.device
 


### PR DESCRIPTION
- Bumped bittensor version to 6.11.0
- Bittensor >=6.10.0 introduced some changes to their logging infra so I had to accomodate for that (see commits)