### PR TITLE
hotfix: wandb rollover after certain number of wandb logs

### DIFF
--- a/sturdy/__init__.py
+++ b/sturdy/__init__.py
@@ -17,7 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the version of the template module.
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/sturdy/utils/config.py
+++ b/sturdy/utils/config.py
@@ -230,6 +230,13 @@ def add_validator_args(cls, parser):
     )
 
     parser.add_argument(
+        "--wandb.run_log_limit",
+        type=int,
+        help="Number of wandb.log() calls after which we should init a new wandb run",
+        default=280,
+    )
+
+    parser.add_argument(
         "--api_port",
         type=int,
         help="The port you want the api to run on",

--- a/sturdy/utils/wandb.py
+++ b/sturdy/utils/wandb.py
@@ -33,9 +33,11 @@ def init_wandb_miner(self, reinit=False):
         entity=self.config.wandb.entity,
         config=wandb_config,
         mode="offline" if self.config.wandb.offline else "online",
-        dir=self.config.neuron.full_path
-        if self.config.neuron is not None
-        else "wandb_logs",
+        dir=(
+            self.config.neuron.full_path
+            if self.config.neuron is not None
+            else "wandb_logs"
+        ),
         tags=tags,
         notes=self.config.wandb.notes,
     )
@@ -81,3 +83,17 @@ def init_wandb_validator(self, reinit=False):
     bt.logging.success(
         prefix="Started a new wandb run for validator",
     )
+
+
+def reinit_wandb(self):
+    if hasattr(self, "wandb"):
+        if self.wandb is not None:
+            bt.logging.info("Reinitializing wandb")
+            init_wandb_validator(self, reinit=True)
+            bt.logging.info("Reinitialized wandb")
+
+
+def should_reinit_wandb(self):
+    if self.wandb_run_log_count >= self.config.wandb.run_log_limit:
+        return True
+    return False


### PR DESCRIPTION
This updates adds support for rolling over (reinitializing) wandb runs automatically after a certain number of logs have been made. This has been done as a workaround to what appears to be a ~100K log line limit on wandb. 