### PR TITLE
fixed numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ bittensor==6.11.0
 torch==2.0.1
 typer==0.9.0
 starlette==0.27.0
+numpy==1.26.4


### PR DESCRIPTION
the latest version of numpy (2.0.0) which was released today is breaking `wandb==0.17.0` package, need to install the previous version of numpy to get it fixed
the exception itself is

```
AttributeError: `np.float_` was removed in the NumPy 2.0 release. Use 
`np.float64` instead.
/root/sturdy-subnet/myenv/lib/python3.10/site-packages/eth_utils/network.py:44: UserWarning: Network 345 with name 'Yooldo Verse Mainnet' does not have a valid ChainId. eth-typing should be updated with the latest networks.
  warnings.warn(
/root/sturdy-subnet/myenv/lib/python3.10/site-packages/eth_utils/network.py:44: UserWarning: Network 12611 with name 'Astar zkEVM' does not have a valid ChainId. eth-typing should be updated with the latest networks.
  warnings.warn(
╭───────────────────── Traceback (most recent call last) ──────────────────────╮
│ /root/sturdy-subnet/neurons/miner.py:24 in <module>                          │
│                                                                              │
│    21 import bittensor as bt                                                 │
│    22                                                                        │
│    23 # Bittensor Miner Template:                                            │
│ ❱  24 import sturdy                                                          │
│    25                                                                        │
│    26 # import base miner class which takes care of most of the boilerplate  │
│    27 from sturdy.base.miner import BaseMinerNeuron                          │
│                                                                              │
│ /root/sturdy-subnet/sturdy/__init__.py:31 in <module>                        │
│                                                                              │
│   28 # Import all submodules.                                                │
│   29 from . import protocol                                                  │
│   30 from . import base                                                      │
│ ❱ 31 from . import validator                                                 │
│   32 from .subnet_links import SUBNET_LINKS                                  │
│   33                                                                         │
│                                                                              │
│ /root/sturdy-subnet/sturdy/validator/__init__.py:1 in <module>               │
│                                                                              │
│ ❱ 1 from .forward import forward, query_and_score_miners                     │
│   2 from .reward import reward                                               │
│   3                                                                          │
│                                                                              │
│ /root/sturdy-subnet/sturdy/validator/forward.py:24 in <module>               │
│                                                                              │
│    21 import asyncio                                                         │
│    22                                                                        │
│    23 from sturdy.protocol import AllocateAssets                             │
│ ❱  24 from sturdy.validator.reward import get_rewards                        │
│    25 from sturdy.protocol import AllocInfo                                  │
│    26 from sturdy.constants import QUERY_TIMEOUT                             │
│    27                                                                        │
│                                                                              │
│ /root/sturdy-subnet/sturdy/validator/reward.py:28 in <module>                │
│                                                                              │
│    25 import copy                                                            │
│    26                                                                        │
│    27 from sturdy.constants import QUERY_TIMEOUT, STEEPNESS, DIV_FACTOR, NUM │
│ ❱  28 from sturdy.utils.misc import supply_rate, check_allocations           │
│    29 from sturdy.protocol import AllocInfo                                  │
│    30                                                                        │
│    31                                                                        │
│                                                                              │
│ /root/sturdy-subnet/sturdy/utils/__init__.py:4 in <module>                   │
│                                                                              │
│   1 from . import config                                                     │
│   2 from . import misc                                                       │
│   3 from . import uids                                                       │
│ ❱ 4 from . import wandb                                                      │
│   5                                                                          │
│                                                                              │
│ /root/sturdy-subnet/sturdy/utils/wandb.py:1 in <module>                      │
│                                                                              │
│ ❱   1 import wandb                                                           │
│     2 import bittensor as bt                                                 │
│     3 import copy                                                            │
│     4                                                                        │
│                                                                              │
│ /root/sturdy-subnet/myenv/lib/python3.10/site-packages/wandb/__init__.py:27  │
│ in <module>                                                                  │
│                                                                              │
│    24 # This needs to be early as other modules call it.                     │
│    25 from wandb.errors.term import termsetup, termlog, termerror, termwarn  │
│    26                                                                        │
│ ❱  27 from wandb import sdk as wandb_sdk                                     │
│    28                                                                        │
│    29 import wandb                                                           │
│    30                                                                        │
│                                                                              │
│ /root/sturdy-subnet/myenv/lib/python3.10/site-packages/wandb/sdk/__init__.py │
│ :25 in <module>                                                              │
│                                                                              │
│   22 )                                                                       │
│   23                                                                         │
│   24 from . import wandb_helper as helper                                    │
│ ❱ 25 from .artifacts.artifact import Artifact                                │
│   26 from .wandb_alerts import AlertLevel                                    │
│   27 from .wandb_config import Config                                        │
│   28 from .wandb_init import _attach, init                                   │
│                                                                              │
│ /root/sturdy-subnet/myenv/lib/python3.10/site-packages/wandb/sdk/artifacts/a │
│ rtifact.py:45 in <module>                                                    │
│                                                                              │
│     42 import requests                                                       │
│     43                                                                       │
│     44 import wandb                                                          │
│ ❱   45 from wandb import data_types, env, util                               │
│     46 from wandb.apis.normalize import normalize_exceptions                 │
│     47 from wandb.apis.public import ArtifactCollection, ArtifactFiles, Retr │
│     48 from wandb.data_types import WBValue                                  │
│                                                                              │
│ /root/sturdy-subnet/myenv/lib/python3.10/site-packages/wandb/data_types.py:3 │
│ 2 in <module>                                                                │
│                                                                              │
│     29 from wandb import util                                                │
│     30 from wandb.sdk.lib import filesystem                                  │
│     31                                                                       │
│ ❱   32 from .sdk.data_types import _dtypes                                   │
│     33 from .sdk.data_types._private import MEDIA_TMP                        │
│     34 from .sdk.data_types.base_types.media import (                        │
│     35 │   BatchableMedia,                                                   │
│                                                                              │
│ /root/sturdy-subnet/myenv/lib/python3.10/site-packages/wandb/sdk/data_types/ │
│ _dtypes.py:393 in <module>                                                   │
│                                                                              │
│   390 │   NumberType.types.append(np.uintp)                                  │
│   391 │   NumberType.types.append(np.float32)                                │
│   392 │   NumberType.types.append(np.float64)                                │
│ ❱ 393 │   NumberType.types.append(np.float_)                                 │
│   394 │   NumberType.types.append(np.complex64)                              │
│   395 │   NumberType.types.append(np.complex128)                             │
│   396 │   NumberType.types.append(np.complex_)                               │
│                                                                              │
│ /root/sturdy-subnet/myenv/lib/python3.10/site-packages/numpy/__init__.py:397 │
│ in __getattr__                                                               │
│                                                                              │
│   394 │   │   │   raise AttributeError(__former_attrs__[attr])               │
│   395 │   │                                                                  │
│   396 │   │   if attr in __expired_attributes__:                             │
│ ❱ 397 │   │   │   raise AttributeError(                                      │
│   398 │   │   │   │   f"`np.{attr}` was removed in the NumPy 2.0 release. "  │
│   399 │   │   │   │   f"{__expired_attributes__[attr]}"                      │
│   400 │   │   │   )                                                          │
╰──────────────────────────────────────────────────────────────────────────────╯
```


 