### PR TITLE
Hotfix: Simulator Rate Change Calculation

### DIFF
--- a/min_compute.yml
+++ b/min_compute.yml
@@ -10,7 +10,7 @@
 # Even then - storage isn't utilized very often - so disk performance won't really be a bottleneck vs, CPU, RAM, 
 # and network bandwidth.
 
-version: '1.3.0' # update this version key as needed, ideally should match your release version
+version: '1.3.1' # update this version key as needed, ideally should match your release version
 
 compute_spec:
 

--- a/sturdy/__init__.py
+++ b/sturdy/__init__.py
@@ -17,7 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the version of the template module.
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/sturdy/validator/simulator.py
+++ b/sturdy/validator/simulator.py
@@ -147,7 +147,7 @@ class Simulator(object):
             0, self.stochasticity * 1e18, len(curr_borrow_rates)
         )  # Add some random noise
         rate_changes = (
-            -self.reversion_speed * ((curr_borrow_rates - median_rate) // 1e18) + noise
+            (-self.reversion_speed * (curr_borrow_rates - median_rate)) + noise
         )  # Mean reversion principle
         new_borrow_amounts = curr_borrow_amounts + wei_mul_arrays(
             rate_changes, curr_borrow_amounts


### PR DESCRIPTION
- Fixed simulator rate change calculation. Originally assumed that reversion speed was in units of wei when it was in fact not.