### PR TITLE
Updated Spec - Use Contract Addresses In Place Of Pool IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,56 +53,64 @@ There are three core files.
   used for generating a dummy `assets_and_pools` taken from [pools.py](./sturdy/pools.py) used for
   synthetic requests:
     ```python
-    def generate_assets_and_pools(rng_gen=np.random) -> Dict:  # generate pools
-        assets_and_pools = {}
+  def generate_eth_public_key(rng_gen=np.random) -> str:
+      private_key_bytes = rng_gen.bytes(32)
+      account = Account.from_key(private_key_bytes)
+      eth_address = account.address
 
-        pools = [
-            BasePool(
-                pool_id=str(x),
-                pool_type=POOL_TYPES.SYNTHETIC,
-                base_rate=randrange_float(
-                    MIN_BASE_RATE, MAX_BASE_RATE, BASE_RATE_STEP, rng_gen=rng_gen
-                ),
-                base_slope=randrange_float(
-                    MIN_SLOPE, MAX_SLOPE, SLOPE_STEP, rng_gen=rng_gen
-                ),
-                kink_slope=randrange_float(
-                    MIN_KINK_SLOPE, MAX_KINK_SLOPE, SLOPE_STEP, rng_gen=rng_gen
-                ),  # kink rate - kicks in after pool hits optimal util rate
-                optimal_util_rate=randrange_float(
-                    MIN_OPTIMAL_RATE,
-                    MAX_OPTIMAL_RATE,
-                    OPTIMAL_UTIL_STEP,
-                    rng_gen=rng_gen,
-                ),  # optimal util rate - after which the kink slope kicks in
-                borrow_amount=int(
-                    format_num_prec(
-                        wei_mul(
-                            POOL_RESERVE_SIZE,
-                            randrange_float(
-                                MIN_UTIL_RATE,
-                                MAX_UTIL_RATE,
-                                UTIL_RATE_STEP,
-                                rng_gen=rng_gen,
-                            ),
-                        )
-                    )
-                ),  # initial borrowed amount from pool
-                reserve_size=POOL_RESERVE_SIZE,
-            )
-            for x in range(NUM_POOLS)
-        ]
+      return eth_address
 
-        pools = {str(pool.pool_id): pool for pool in pools}
 
-        assets_and_pools["total_assets"] = math.floor(
-            randrange_float(
-                MIN_TOTAL_ASSETS, MAX_TOTAL_ASSETS, TOTAL_ASSETS_STEP, rng_gen=rng_gen
-            )
-        )
-        assets_and_pools["pools"] = pools
+  def generate_assets_and_pools(rng_gen=np.random) -> Dict:  # generate pools
+      assets_and_pools = {}
 
-        return assets_and_pools
+      pools = [
+          BasePool(
+              contract_address=generate_eth_public_key(rng_gen=rng_gen),
+              pool_type=POOL_TYPES.SYNTHETIC,
+              base_rate=randrange_float(
+                  MIN_BASE_RATE, MAX_BASE_RATE, BASE_RATE_STEP, rng_gen=rng_gen
+              ),
+              base_slope=randrange_float(
+                  MIN_SLOPE, MAX_SLOPE, SLOPE_STEP, rng_gen=rng_gen
+              ),
+              kink_slope=randrange_float(
+                  MIN_KINK_SLOPE, MAX_KINK_SLOPE, SLOPE_STEP, rng_gen=rng_gen
+              ),  # kink rate - kicks in after pool hits optimal util rate
+              optimal_util_rate=randrange_float(
+                  MIN_OPTIMAL_RATE,
+                  MAX_OPTIMAL_RATE,
+                  OPTIMAL_UTIL_STEP,
+                  rng_gen=rng_gen,
+              ),  # optimal util rate - after which the kink slope kicks in
+              borrow_amount=int(
+                  format_num_prec(
+                      wei_mul(
+                          POOL_RESERVE_SIZE,
+                          randrange_float(
+                              MIN_UTIL_RATE,
+                              MAX_UTIL_RATE,
+                              UTIL_RATE_STEP,
+                              rng_gen=rng_gen,
+                          ),
+                      )
+                  )
+              ),  # initial borrowed amount from pool
+              reserve_size=POOL_RESERVE_SIZE,
+          )
+          for _ in range(NUM_POOLS)
+      ]
+
+      pools = {str(pool.contract_address): pool for pool in pools}
+
+      assets_and_pools["total_assets"] = math.floor(
+          randrange_float(
+              MIN_TOTAL_ASSETS, MAX_TOTAL_ASSETS, TOTAL_ASSETS_STEP, rng_gen=rng_gen
+          )
+      )
+      assets_and_pools["pools"] = pools
+
+      return assets_and_pools
     ```
     Validators can optionally run an API server and sell their bandwidth to outside users to send
     their own pools (organic requests) to the subnet. For more information on this process - please read

--- a/docs/validator.md
+++ b/docs/validator.md
@@ -201,30 +201,26 @@ curl -X POST \
   "request_type": "ORGANIC",
   "user_address": "0xD8f9475A4A1A6812212FD62e80413d496038A89A",
   "assets_and_pools": {
-    "total_assets": 1000000000000000000,
+    "total_assets": 4070000000000000000000,
     "pools": {
-      "Sturdy ETH/rsETH silo": {
-        "pool_model_disc": "CHAIN",
+      "0xe53FFd56FaDC7030156069aE1b34dE0Ab8b703F4": {
+      	"pool_model_disc": "CHAIN",
         "pool_type": "STURDY_SILO",
-        "pool_id": "Sturdy ETH/rsETH silo",
         "contract_address": "0xe53FFd56FaDC7030156069aE1b34dE0Ab8b703F4"
       },
-      "Sturdy ETH/rswETH Pendle PT silo": {
-        "pool_model_disc": "CHAIN",
+      "0xC8D4a8a7F593e73cD32cD6C5Fb11fE20F23f9695": {
+      	"pool_model_disc": "CHAIN",
         "pool_type": "STURDY_SILO",
-        "pool_id": "Sturdy ETH/rswETH Pendle PT silo",
         "contract_address": "0xC8D4a8a7F593e73cD32cD6C5Fb11fE20F23f9695"
       },
-      "Sturdy ETH/SwETH silo": {
-        "pool_model_disc": "CHAIN",
+      "0xD002Dc1c05fd7FF28C55eEA3dDcB9051B2B81bD2": {
+      	"pool_model_disc": "CHAIN",
         "pool_type": "STURDY_SILO",
-        "pool_id": "Sturdy ETH/SwETH silo",
         "contract_address": "0xD002Dc1c05fd7FF28C55eEA3dDcB9051B2B81bD2"
       },
-      "Sturdy ETH/Sommelier Turbo stETH silo": {
-        "pool_model_disc": "CHAIN",
+      "0x0DD49C449C788285F50B529145D6e6E76f02Fd8f": {
+      	"pool_model_disc": "CHAIN",
         "pool_type": "STURDY_SILO",
-        "pool_id": "Sturdy ETH/Sommelier Turbo stETH silo",
         "contract_address": "0x0DD49C449C788285F50B529145D6e6E76f02Fd8f"
       }
     }
@@ -240,28 +236,28 @@ And the corresponding response(example) format from the subnet:
         "1": {
             "apy": 2609043057391825,
             "allocations": {
-                "Sturdy ETH/rsETH silo": 250000000000000000,
-                "Sturdy ETH/rswETH Pendle PT silo": 250000000000000000,
-                "Sturdy ETH/SwETH silo": 250000000000000000,
-                "Sturdy ETH/Sommelier Turbo stETH silo": 250000000000000000
+                "0xe53FFd56FaDC7030156069aE1b34dE0Ab8b703F4": 250000000000000000,
+                "0xC8D4a8a7F593e73cD32cD6C5Fb11fE20F23f9695": 250000000000000000,
+                "0xD002Dc1c05fd7FF28C55eEA3dDcB9051B2B81bD2": 250000000000000000,
+                "0x0DD49C449C788285F50B529145D6e6E76f02Fd8f": 250000000000000000
             }
         },
         "2": {
             "apy": 2609043057391825,
             "allocations": {
-                "Sturdy ETH/rsETH silo": 250000000000000000,
-                "Sturdy ETH/rswETH Pendle PT silo": 250000000000000000,
-                "Sturdy ETH/SwETH silo": 250000000000000000,
-                "Sturdy ETH/Sommelier Turbo stETH silo": 250000000000000000
+                "0xe53FFd56FaDC7030156069aE1b34dE0Ab8b703F4": 250000000000000000,
+                "0xC8D4a8a7F593e73cD32cD6C5Fb11fE20F23f9695": 250000000000000000,
+                "0xD002Dc1c05fd7FF28C55eEA3dDcB9051B2B81bD2": 250000000000000000,
+                "0x0DD49C449C788285F50B529145D6e6E76f02Fd8f": 250000000000000000
             }
         },
         "4": {
             "apy": 2609043057391825,
             "allocations": {
-                "Sturdy ETH/rsETH silo": 250000000000000000,
-                "Sturdy ETH/rswETH Pendle PT silo": 250000000000000000,
-                "Sturdy ETH/SwETH silo": 250000000000000000,
-                "Sturdy ETH/Sommelier Turbo stETH silo": 250000000000000000
+                "0xe53FFd56FaDC7030156069aE1b34dE0Ab8b703F4": 250000000000000000,
+                "0xC8D4a8a7F593e73cD32cD6C5Fb11fE20F23f9695": 250000000000000000,
+                "0xD002Dc1c05fd7FF28C55eEA3dDcB9051B2B81bD2": 250000000000000000,
+                "0x0DD49C449C788285F50B529145D6e6E76f02Fd8f": 250000000000000000
             }
         }
     }

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -192,9 +192,9 @@ async def allocate(body: AllocateAssetsRequest):
           "assets_and_pools": {
             "total_assets": 1000000000000000000,
             "pools": {
+              ...
               "Sturdy ETH/rsETH silo": {
                 "pool_type": "STURDY_SILO",
-                "pool_id": "Sturdy ETH/rsETH silo",
                 "contract_address": "0xe53FFd56FaDC7030156069aE1b34dE0Ab8b703F4"
               },
               ...
@@ -206,10 +206,12 @@ async def allocate(body: AllocateAssetsRequest):
         {
             "request_uuid": "a8af54a41fa347d7b59570c81fe35492",
             "allocations": {
+                ...
                 "1": {
                     "apy": 2609043057391825,
                     "allocations": {
-                        "Sturdy ETH/rsETH silo": 250000000000000000,
+                        ...
+                        "0xe53FFd56FaDC7030156069aE1b34dE0Ab8b703F4": 250000000000000000,
                         ...
                     }
                 },
@@ -227,7 +229,7 @@ async def allocate(body: AllocateAssetsRequest):
             case REQUEST_TYPES.SYNTHETIC:
                 new_pool = PoolFactory.create_pool(
                     pool_type=pool.pool_type,
-                    pool_id=pool.pool_id,
+                    contract_address=pool.contract_address,
                     base_rate=pool.base_rate,
                     base_slope=pool.base_slope,
                     kink_slope=pool.kink_slope,
@@ -240,7 +242,6 @@ async def allocate(body: AllocateAssetsRequest):
                 new_pool = PoolFactory.create_pool(
                     pool_type=pool.pool_type,
                     web3_provider=core_validator.w3,
-                    pool_id=pool.pool_id,
                     user_address=(
                         pool.user_address
                         if pool.user_address != web3.constants.ADDRESS_ZERO

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ starlette==0.27.0
 web3==6.19.0
 numpy==1.26.4
 python-dotenv==1.0.1
+pandas==2.2.2
+matplotlib==3.9.0

--- a/sturdy/algo.py
+++ b/sturdy/algo.py
@@ -62,19 +62,19 @@ def naive_algorithm(self: BaseMinerNeuron, synapse: AllocateAssets) -> Dict:
         match pool.pool_type:
             case POOL_TYPES.AAVE:
                 apy = pool.supply_rate(synapse.user_address, balance // len(pools))
-                supply_rates[pool.pool_id] = apy
+                supply_rates[pool.contract_address] = apy
                 supply_rate_sum += apy
             case T if T in (POOL_TYPES.STURDY_SILO, POOL_TYPES.COMPOUND_V3):
                 apy = pool.supply_rate(balance // len(pools))
-                supply_rates[pool.pool_id] = apy
+                supply_rates[pool.contract_address] = apy
                 supply_rate_sum += apy
             case POOL_TYPES.DAI_SAVINGS:
                 apy = pool.supply_rate()
-                supply_rates[pool.pool_id] = apy
+                supply_rates[pool.contract_address] = apy
                 supply_rate_sum += apy
             case POOL_TYPES.SYNTHETIC:
                 apy = pool.supply_rate
-                supply_rates[pool.pool_id] = apy
+                supply_rates[pool.contract_address] = apy
                 supply_rate_sum += apy
             case _:
                 pass

--- a/sturdy/utils/misc.py
+++ b/sturdy/utils/misc.py
@@ -130,7 +130,9 @@ def supply_rate(util_rate, pool):
 
 def check_allocations(
     assets_and_pools: Dict[str, Union[Dict[str, int], int]],
-    allocations: Dict[str, int],
+    allocations: Dict[
+        str, int
+    ],  # TODO: fix circular import so we can type this with AllocationsDict?
 ) -> bool:
     """
     Checks allocations from miner.

--- a/sturdy/validator/reward.py
+++ b/sturdy/validator/reward.py
@@ -26,7 +26,7 @@ from sturdy.constants import QUERY_TIMEOUT, SIMILARITY_THRESHOLD
 from sturdy.pools import POOL_TYPES, BasePoolModel, ChainBasedPoolModel
 from sturdy.utils.ethmath import wei_div, wei_mul
 from sturdy.utils.misc import check_allocations
-from sturdy.protocol import REQUEST_TYPES, AllocInfo
+from sturdy.protocol import REQUEST_TYPES, AllocInfo, AllocationsDict
 
 
 def get_response_times(uids: List[int], responses, timeout: float) -> Dict[str, int]:
@@ -60,7 +60,7 @@ def get_response_times(uids: List[int], responses, timeout: float) -> Dict[str, 
 
 
 def format_allocations(
-    allocations: Dict[str, int],
+    allocations: AllocationsDict,
     assets_and_pools: Dict[
         str, Union[Dict[str, Union[ChainBasedPoolModel, BasePoolModel]], int]
     ],
@@ -72,12 +72,12 @@ def format_allocations(
     pools = assets_and_pools["pools"]
 
     # pad the allocations
-    for pool_id in pools.keys():
-        if pool_id not in allocs:
-            allocs[pool_id] = 0
+    for contract_addr in pools.keys():
+        if contract_addr not in allocs:
+            allocs[contract_addr] = 0
 
-    # sort the allocations by pool id
-    formatted_allocs = {pool_id: allocs[pool_id] for pool_id in sorted(allocs.keys())}
+    # sort the allocations by contract address
+    formatted_allocs = {contract_addr: allocs[contract_addr] for contract_addr in sorted(allocs.keys())}
 
     return formatted_allocs
 
@@ -128,7 +128,7 @@ def calculate_rewards_with_adjusted_penalties(miners, rewards_apy, penalties):
 
 
 def get_similarity_matrix(
-    apys_and_allocations: Dict[str, Dict[str, Union[Dict[str, int], int]]],
+    apys_and_allocations: Dict[str, Dict[str, Union[AllocationsDict, int]]],
     assets_and_pools: Dict[str, Union[Dict[str, int], int]],
 ):
     """
@@ -143,10 +143,10 @@ def get_similarity_matrix(
     possible distance between the allocation 'vectors'.
 
     Args:
-        apys_and_allocations (Dict[str, Dict[str, Union[Dict[str, int], int]]]):
+        apys_and_allocations (Dict[str, Dict[str, Union[AllocationsDict, int]]]):
             A dictionary containing the APY and allocation strategies for each miner. The keys are miner identifiers,
             and the values are dictionaries with their respective allocations and APYs.
-        assets_and_pools (Dict[str, Union[Dict[str, int], int]]):
+        assets_and_pools (Dict[str, Union[AllocationsDict, int]]):
             A dictionary representing the assets available to the miner as well as the pools they can allocate to
 
     Returns:
@@ -183,7 +183,7 @@ def get_similarity_matrix(
 
 def adjust_rewards_for_plagiarism(
     rewards_apy: torch.FloatTensor,
-    apys_and_allocations: Dict[str, Dict[str, Union[Dict[str, int], int]]],
+    apys_and_allocations: Dict[str, Dict[str, Union[AllocationsDict, int]]],
     assets_and_pools: Dict[
         str, Union[Dict[str, Union[ChainBasedPoolModel, BasePoolModel]], int]
     ],
@@ -202,7 +202,7 @@ def adjust_rewards_for_plagiarism(
 
     Args:
         rewards_apy (torch.FloatTensor): The initial APY rewards for the miners, before adjustments.
-        apys_and_allocations (Dict[str, Dict[str, Union[Dict[str, int], int]]]):
+        apys_and_allocations (Dict[str, Dict[str, Union[AllocationsDict, int]]]):
             A dictionary containing APY values and allocation strategies for each miner. The keys are miner identifiers,
             and the values are dictionaries that include their allocations and APYs.
         assets_and_pools (Dict[str, Union[Dict[str, int], int]]):
@@ -236,7 +236,7 @@ def _get_rewards(
     self,
     query: int,
     max_apy: float,
-    apys_and_allocations: Dict[str, Dict[str, Union[Dict[str, int], int]]],
+    apys_and_allocations: Dict[str, Dict[str, Union[AllocationsDict, int]]],
     assets_and_pools: Dict[
         str, Union[Dict[str, Union[ChainBasedPoolModel, BasePoolModel]], int]
     ],
@@ -271,7 +271,7 @@ def _get_rewards(
 
 def calculate_apy(
     self,
-    allocations: Dict[str, int],
+    allocations: AllocationsDict,
     assets_and_pools: Dict[
         str, Union[Dict[str, Union[ChainBasedPoolModel, BasePoolModel]], int]
     ],
@@ -310,7 +310,7 @@ def calculate_apy(
 
 
 def calculate_aggregate_apy(
-    allocations: Dict[str, int],
+    allocations: AllocationsDict,
     assets_and_pools: Dict[
         str, Union[Dict[str, Union[ChainBasedPoolModel, BasePoolModel]], int]
     ],

--- a/sturdy/validator/simulator.py
+++ b/sturdy/validator/simulator.py
@@ -1,6 +1,7 @@
 import numpy as np
 from typing import Dict, Union
 
+from sturdy.protocol import AllocationsDict
 from sturdy.utils.ethmath import wei_mul_arrays
 from sturdy.utils.misc import check_allocations
 from sturdy.pools import (
@@ -33,7 +34,7 @@ class Simulator(object):
         init_assets_and_pools: Dict[
             str, Union[Dict[str, Union[ChainBasedPoolModel, BasePoolModel]], int]
         ] = None,
-        init_allocations: Dict[str, int] = None,
+        init_allocations: AllocationsDict = None,
     ):
         if self.rng_state_container is None or self.init_rng is None:
             raise RuntimeError(

--- a/tests/integration/validator/test_integration_validator.py
+++ b/tests/integration/validator/test_integration_validator.py
@@ -2,8 +2,10 @@ import unittest
 from unittest import IsolatedAsyncioTestCase
 import copy
 
+import numpy as np
+
 from neurons.validator import Validator
-from sturdy.pools import BasePool
+from sturdy.pools import generate_assets_and_pools
 from sturdy.validator.simulator import Simulator
 
 from sturdy.validator.forward import query_and_score_miners
@@ -26,113 +28,26 @@ class TestValidator(IsolatedAsyncioTestCase):
         # simulator with preset seed
         cls.validator.simulator = Simulator(seed=69)
 
+        assets_and_pools = generate_assets_and_pools(np.random.RandomState(seed=420))
+
         cls.assets_and_pools = {
-            "pools": {
-                "0": BasePool(
-                    base_rate=int(0.03e18),
-                    base_slope=int(0.072e18),
-                    borrow_amount=int(385e18),
-                    kink_slope=int(0.347e18),
-                    optimal_util_rate=int(0.9e18),
-                    pool_id="0",
-                    reserve_size=500e18,
-                ),
-                "1": BasePool(
-                    base_rate=int(0.01e18),
-                    base_slope=int(0.011e18),
-                    borrow_amount=int(55e18),
-                    kink_slope=int(0.187e18),
-                    optimal_util_rate=int(0.9e18),
-                    pool_id="1",
-                    reserve_size=500e18,
-                ),
-                "2": BasePool(
-                    base_rate=int(0.02e18),
-                    base_slope=int(0.067e18),
-                    borrow_amount=int(270e18),
-                    kink_slope=int(0.662e18),
-                    optimal_util_rate=int(0.9e18),
-                    pool_id="2",
-                    reserve_size=500e18,
-                ),
-                "3": BasePool(
-                    base_rate=int(0.01e18),
-                    base_slope=int(0.044e18),
-                    borrow_amount=int(70e18),
-                    kink_slope=int(0.386e18),
-                    optimal_util_rate=int(0.9e18),
-                    pool_id="3",
-                    reserve_size=500e18,
-                ),
-                "4": BasePool(
-                    base_rate=int(0.03e18),
-                    base_slope=int(0.044e18),
-                    borrow_amount=int(75e18),
-                    kink_slope=int(0.163e18),
-                    optimal_util_rate=int(0.65e18),
-                    pool_id="4",
-                    reserve_size=500e18,
-                ),
-                "5": BasePool(
-                    base_rate=int(0.05e18),
-                    base_slope=int(0.021e18),
-                    borrow_amount=int(185e18),
-                    kink_slope=int(0.232e18),
-                    optimal_util_rate=int(0.75e18),
-                    pool_id="5",
-                    reserve_size=500e18,
-                ),
-                "6": BasePool(
-                    base_rate=int(0.01e18),
-                    base_slope=int(0.062e18),
-                    borrow_amount=int(170e18),
-                    kink_slope=int(0.997e18),
-                    optimal_util_rate=int(0.8e18),
-                    pool_id="6",
-                    reserve_size=500e18,
-                ),
-                "7": BasePool(
-                    base_rate=int(0.02e18),
-                    base_slope=int(0.098e18),
-                    borrow_amount=int(290e18),
-                    kink_slope=int(0.543e18),
-                    optimal_util_rate=int(0.75e18),
-                    pool_id="7",
-                    reserve_size=500e18,
-                ),
-                "8": BasePool(
-                    base_rate=int(0.01e18),
-                    base_slope=int(0.028e18),
-                    borrow_amount=int(355e18),
-                    kink_slope=int(0.352e18),
-                    optimal_util_rate=int(0.8e18),
-                    pool_id="8",
-                    reserve_size=500e18,
-                ),
-                "9": BasePool(
-                    base_rate=int(0.04e18),
-                    base_slope=int(0.066e18),
-                    borrow_amount=int(170e18),
-                    kink_slope=int(0.617e18),
-                    optimal_util_rate=int(0.8e18),
-                    pool_id="9",
-                    reserve_size=500e18,
-                ),
-            },
+            "pools": assets_and_pools["pools"],
             "total_assets": int(1000e18),
         }
 
+        cls.contract_addresses = list(assets_and_pools["pools"].keys())
+
         cls.allocations = {
-            "0": 100e18,
-            "1": 100e18,
-            "2": 200e18,
-            "3": 50e18,
-            "4": 200e18,
-            "5": 25e18,
-            "6": 25e18,
-            "7": 50e18,
-            "8": 50e18,
-            "9": 200e18,
+            cls.contract_addresses[0]: 100e18,
+            cls.contract_addresses[1]: 100e18,
+            cls.contract_addresses[2]: 200e18,
+            cls.contract_addresses[3]: 50e18,
+            cls.contract_addresses[4]: 200e18,
+            cls.contract_addresses[5]: 25e18,
+            cls.contract_addresses[6]: 25e18,
+            cls.contract_addresses[7]: 50e18,
+            cls.contract_addresses[8]: 50e18,
+            cls.contract_addresses[9]: 200e18,
         }
 
     async def test_query_and_score_miners(self):

--- a/tests/unit/validator/test_pool_generator.py
+++ b/tests/unit/validator/test_pool_generator.py
@@ -26,7 +26,7 @@ class TestPoolAndAllocGeneration(unittest.TestCase):
             self.assertEqual(len(result["pools"]), NUM_POOLS)
 
             # Assert properties of each pool
-            for pool_id, pool_info in result["pools"].items():
+            for _, pool_info in result["pools"].items():
                 self.assertTrue(hasattr(pool_info, "base_rate"))
                 self.assertTrue(
                     MIN_BASE_RATE <= pool_info.base_rate <= MAX_BASE_RATE

--- a/tests/unit/validator/test_pool_models.py
+++ b/tests/unit/validator/test_pool_models.py
@@ -71,7 +71,6 @@ class TestAavePool(unittest.TestCase):
         print("----==== test_pool_contract ====----")
         # we call the aave3 weth atoken proxy contract in this example
         pool = AaveV3DefaultInterestRatePool(
-            pool_id="test",
             contract_address=self.atoken_address,
         )
 
@@ -86,7 +85,6 @@ class TestAavePool(unittest.TestCase):
     def test_sync(self):
         print("----==== test_sync ====----")
         pool = AaveV3DefaultInterestRatePool(
-            pool_id="test",
             contract_address=self.atoken_address,
         )
 
@@ -103,7 +101,6 @@ class TestAavePool(unittest.TestCase):
     def test_supply_rate_alloc(self):
         print("----==== test_supply_rate_increase_alloc ====----")
         pool = AaveV3DefaultInterestRatePool(
-            pool_id="test",
             contract_address=self.atoken_address,
         )
 
@@ -128,7 +125,6 @@ class TestAavePool(unittest.TestCase):
     def test_supply_rate_decrease_alloc(self):
         print("----==== test_supply_rate_decrease_alloc ====----")
         pool = AaveV3DefaultInterestRatePool(
-            pool_id="test",
             contract_address=self.atoken_address,
         )
 
@@ -266,7 +262,6 @@ class TestSturdySiloStrategy(unittest.TestCase):
         print("----==== test_pool_contract ====----")
         # we call the aave3 weth atoken proxy contract in this example
         pool = VariableInterestSturdySiloStrategy(
-            pool_id="test",
             contract_address=self.contract_address,
         )
         whale_addr = self.w3.to_checksum_address(
@@ -334,7 +329,6 @@ class TestCompoundV3Pool(unittest.TestCase):
     def test_compound_pool_model(self):
         print("----==== test_compound_pool_model ====----")
         pool = CompoundV3Pool(
-            pool_id="test",
             contract_address=self.ctoken_address,
             user_address=self.user_address,
         )
@@ -363,7 +357,6 @@ class TestCompoundV3Pool(unittest.TestCase):
         print("----==== test_supply_rate_increase_alloc ====----")
 
         pool = CompoundV3Pool(
-            pool_id="test",
             contract_address=self.ctoken_address,
             user_address=self.user_address,
         )
@@ -389,7 +382,6 @@ class TestCompoundV3Pool(unittest.TestCase):
         print("----==== test_supply_rate_decrease_alloc ====----")
 
         pool = CompoundV3Pool(
-            pool_id="test",
             contract_address=self.ctoken_address,
             user_address=self.user_address,
         )
@@ -459,7 +451,6 @@ class TestDaiSavingsRate(unittest.TestCase):
         print("----==== test_dai_savings_rate_contract ====----")
         # we call the aave3 weth atoken proxy contract in this example
         pool = DaiSavingsRate(
-            pool_id="sDai",
             contract_address=self.contract_address,
         )
 

--- a/tests/unit/validator/test_simulator.py
+++ b/tests/unit/validator/test_simulator.py
@@ -56,8 +56,11 @@ class TestSimulator(unittest.TestCase):
 
         init_pools = copy.deepcopy(self.simulator.assets_and_pools["pools"])
 
+        contract_addresses = [addr for addr in self.simulator.assets_and_pools["pools"]]
+
         allocations = {
-            str(i): self.simulator.assets_and_pools["total_assets"] / len(init_pools)
+            contract_addresses[i]: self.simulator.assets_and_pools["total_assets"]
+            / len(init_pools)
             for i in range(len(init_pools))
         }
 
@@ -90,7 +93,11 @@ class TestSimulator(unittest.TestCase):
         init_pools = copy.deepcopy(self.simulator.assets_and_pools["pools"])
         total_assets = self.simulator.assets_and_pools["total_assets"]
 
-        allocs = {"0": total_assets / 10}  # should be 0.1 if total assets is 1
+        contract_addresses = [addr for addr in self.simulator.assets_and_pools["pools"]]
+
+        allocs = {
+            contract_addresses[0]: total_assets / 10
+        }  # should be 0.1 if total assets is 1
 
         self.simulator.update_reserves_with_allocs(allocs)
 
@@ -188,7 +195,7 @@ class TestSimulator(unittest.TestCase):
             pool_data = self.simulator.pool_history[t]
             self.assertEqual(len(pool_data), NUM_POOLS)
 
-            for pool_id, pool in pool_data.items():
+            for contract_addr, pool in pool_data.items():
                 self.assertTrue(hasattr(pool, "borrow_amount"))
                 self.assertTrue(hasattr(pool, "reserve_size"))
                 self.assertTrue(hasattr(pool, "borrow_rate"))
@@ -196,17 +203,19 @@ class TestSimulator(unittest.TestCase):
                 self.assertGreaterEqual(pool.reserve_size, pool.borrow_amount)
                 self.assertGreaterEqual(pool.borrow_rate, 0)
 
-        for pool_id, _ in self.simulator.assets_and_pools["pools"].items():
+        for contract_addr, _ in self.simulator.assets_and_pools["pools"].items():
             borrow_amounts = [
-                self.simulator.pool_history[T][pool_id].borrow_amount
+                self.simulator.pool_history[T][contract_addr].borrow_amount
                 for T in range(1, self.simulator.timesteps)
             ]
             borrow_rates = [
-                self.simulator.pool_history[T][pool_id].borrow_rate
+                self.simulator.pool_history[T][contract_addr].borrow_rate
                 for T in range(1, self.simulator.timesteps)
             ]
 
-            self.assertTrue(borrow_amounts.count(borrow_amounts[0]) < len(borrow_amounts))
+            self.assertTrue(
+                borrow_amounts.count(borrow_amounts[0]) < len(borrow_amounts)
+            )
             self.assertTrue(borrow_rates.count(borrow_rates[0]) < len(borrow_rates))
 
         # check if simulation runs the same across "reset()s"


### PR DESCRIPTION
We now use contract addresses instead of pool ids for to index allocation values. This has basically been done so that the responses of the subnet is translatable into a more suitable format for on-chain requests via an airnode.

 - [x] Use Contract Addresses In Place Of Pool IDs.