### PR TITLE
fix: workaround for large integer overflow w/ numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ numpy==1.26.4
 python-dotenv==1.0.1
 pandas==2.2.2
 matplotlib==3.9.0
+gmpy2==2.2.1


### PR DESCRIPTION
As reported by @quynhvu4180 [here](https://canary.discord.com/channels/799672011265015819/1217952256306057298/1296318077964648489), attempting to calculate the distance between allocations (numpy arrays) with large numbers results in overflow. This patch introduces `gmpy2` for arbitrary precision arithmetic to serve as a workaround for this issue.