### PR TITLE
fix: Remove reward model distortions

### DIFF
--- a/sturdy/constants.py
+++ b/sturdy/constants.py
@@ -39,7 +39,7 @@ SCORING_PERIOD_STEP = 1800
 SCORING_WINDOW = 300  # scoring window
 
 TOTAL_ALLOC_THRESHOLD = 0.98
-ALLOCATION_SIMILARITY_THRESHOLD = 1e-18  # similarity threshold for plagiarism checking
+ALLOCATION_SIMILARITY_THRESHOLD = 1e-16  # similarity threshold for plagiarism checking
 APY_SIMILARITY_THRESHOLD = 1e-16
 
 DB_DIR = "validator_database.db"  # default validator database dir

--- a/sturdy/constants.py
+++ b/sturdy/constants.py
@@ -39,7 +39,8 @@ SCORING_PERIOD_STEP = 1800
 SCORING_WINDOW = 300  # scoring window
 
 TOTAL_ALLOC_THRESHOLD = 0.98
-SIMILARITY_THRESHOLD = 0.01  # similarity threshold for plagiarism checking
+ALLOCATION_SIMILARITY_THRESHOLD = 1e-18  # similarity threshold for plagiarism checking
+APY_SIMILARITY_THRESHOLD = 1e-16
 
 DB_DIR = "validator_database.db"  # default validator database dir
 

--- a/sturdy/validator/reward.py
+++ b/sturdy/validator/reward.py
@@ -225,16 +225,13 @@ def get_apy_similarity_matrix(
 
     for miner_a, info_a in apys_and_allocations.items():
         apy_a = cast(int, info_a["apy"])
-        apy_a = np.array([gmpy2.mpz(apy_a)])
+        apy_a = np.array([gmpy2.mpz(apy_a)], dtype=object)
         similarity_matrix[miner_a] = {}
         for miner_b, info_b in apys_and_allocations.items():
             if miner_a != miner_b:
                 apy_b = cast(int, info_b["apy"])
-                if apy_a is None or apy_b is None:
-                    similarity_matrix[miner_a][miner_b] = float("inf")
-                    continue
-                apy_b = np.array([gmpy2.mpz(apy_b)])
-                similarity_matrix[miner_a][miner_b] = get_distance(apy_a, apy_b, max(apy_b, apy_b)[0])  # Max scaling
+                apy_b = np.array([gmpy2.mpz(apy_b)], dtype=object)
+                similarity_matrix[miner_a][miner_b] = get_distance(apy_a, apy_b, max(apy_a, apy_b)[0])  # Max scaling
 
     return similarity_matrix
 


### PR DESCRIPTION
Hey @Shr1ftyy @sforman2000,

As described in the issue #63, the subnet churns out high APY miners for low latency miners in large proportions (75%), participating in the flattening of the incentive curve.  This PR addresses the core issue while meeting the initial concerns for cheating / relay mining.

Updates: 

-  Adds an APY similarity matrix
-  Increase penalties calculation sensitivity by decreasing thresholds to match allocation/ apy precision 
-  Update penalties computation to be based on allocation, APY and latency

