### PR TITLE
Release 2.1.4

### DIFF
--- a/min_compute.yml
+++ b/min_compute.yml
@@ -10,7 +10,7 @@
 # Even then - storage isn't utilized very often - so disk performance won't really be a bottleneck vs, CPU, RAM, 
 # and network bandwidth.
 
-version: '2.1.2' # update this version key as needed, ideally should match your release version
+version: '2.1.4' # update this version key as needed, ideally should match your release version
 
 compute_spec:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ loguru==0.7.0
 wandb==0.18.7
 annotated-types==0.7.0
 anyio==4.6.2.post1
-bittensor==8.5.0
+bittensor==8.5.1
 bittensor-cli==8.4.2
 colorama==0.4.6
 decorator==5.1.1

--- a/sturdy/__init__.py
+++ b/sturdy/__init__.py
@@ -17,7 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the version of the template module.
-__version__ = "2.1.3"
+__version__ = "2.1.4"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 

--- a/sturdy/base/neuron.py
+++ b/sturdy/base/neuron.py
@@ -70,14 +70,6 @@ class BaseNeuron(ABC):
         # Set up logging with the provided configuration and directory.
         bt.logging(config=self.config, logging_dir=self.config.full_path)
 
-        # TODO: Surely there's a better way to do this right?
-        # Had to add this because of logging infra changes from bittensor>=6.10.0
-        bt.logging.before_enable_default()
-        if self.config.logging.debug:
-            bt.debug()
-        if self.config.logging.trace:
-            bt.trace()
-
         # If a gpu is required, set the device to cuda:N (e.g. cuda:0)
         self.device = self.config.neuron.device
 

--- a/sturdy/base/validator.py
+++ b/sturdy/base/validator.py
@@ -399,7 +399,7 @@ class BaseValidatorNeuron(BaseNeuron):
 
         # Compute forward pass rewards, assumes uids are mutually exclusive.
         # shape: [ metagraph.n ]
-        scattered_rewards: npt.NDArray = np.empty_like(self.scores)
+        scattered_rewards: npt.NDArray = np.zeros_like(self.scores)
         np.put_along_axis(scattered_rewards, uids_tensor, rewards, axis=0)
         bt.logging.debug(f"Scattered rewards: {rewards}")
 

--- a/sturdy/utils/config.py
+++ b/sturdy/utils/config.py
@@ -228,7 +228,7 @@ def add_validator_args(cls, parser):
         "--wandb.run_log_limit",
         type=int,
         help="Number of wandb.log() calls after which we should init a new wandb run",
-        default=280,
+        default=80,
     )
 
     parser.add_argument(

--- a/sturdy/validator/reward.py
+++ b/sturdy/validator/reward.py
@@ -44,10 +44,10 @@ def get_response_times(uids: list[str], responses, timeout: float) -> dict[str, 
         responses (list[Response]): list of Response objects corresponding to each axon.
 
     Returns:
-        list[Tuple[int, float]]: A sorted list of tuples, where each tuple contains an axon's uid and its response time.
+        dict[str, float]: a dictionary: uid -> process_time
 
     Example:
-        >>> get_sorted_response_times(
+        >>> get_response_times(
         ...     [1, 2, 3],
         ...     [
         ...         response1,
@@ -61,7 +61,6 @@ def get_response_times(uids: list[str], responses, timeout: float) -> dict[str, 
         str(uids[idx]): (response.dendrite.process_time if response.dendrite.process_time is not None else timeout)
         for idx, response in enumerate(responses)
     }
-    # Sorting in ascending order since lower process time is better
 
 
 def format_allocations(
@@ -409,7 +408,7 @@ def filter_allocations(
         # used to filter out miners who timed out
         # TODO: should probably move some things around later down the road
         # TODO: cleaner way to do this?
-        if response.allocations is not None or axon_times[uids[response_idx]] < QUERY_TIMEOUT:
+        if response.allocations is not None and axon_times[uids[response_idx]] < QUERY_TIMEOUT:
             filtered_allocs[uids[response_idx]] = {
                 "allocations": response.allocations,
             }


### PR DESCRIPTION
fix: non-responsive uids shouldn't get big scores
- using `zeros_like` because `empty_like` uses big placeholder nums.
- allocations should not be None AND be responsive
- logging fix