### PR TITLE
Release/2.2.2

### DIFF
--- a/convert_state.py
+++ b/convert_state.py
@@ -63,7 +63,6 @@ def save_torch_state_as_np(state, config) -> None:
         step=to_save["step"],
         scores=to_save["scores"],
         hotkeys=to_save["hotkeys"],
-        last_query_block=to_save["last_query_block"],
     )
 
 

--- a/min_compute.yml
+++ b/min_compute.yml
@@ -10,7 +10,7 @@
 # Even then - storage isn't utilized very often - so disk performance won't really be a bottleneck vs, CPU, RAM, 
 # and network bandwidth.
 
-version: '2.2.1' # update this version key as needed, ideally should match your release version
+version: '2.2.2' # update this version key as needed, ideally should match your release version
 
 compute_spec:
 

--- a/sturdy/__init__.py
+++ b/sturdy/__init__.py
@@ -17,7 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the version of the template module.
-__version__ = "2.2.1"
+__version__ = "2.2.2"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 

--- a/sturdy/constants.py
+++ b/sturdy/constants.py
@@ -28,7 +28,7 @@ MAX_STOCHASTICITY = 0.002  # max stochasticity
 STOCHASTICITY_STEP = 0.0001
 POOL_RESERVE_SIZE = int(100e18)  # 100
 
-QUERY_RATE = 50  # how often synthetic validator queries miners (blocks)
+QUERY_FREQUENCY = 600  # time in seconds between validator queries
 QUERY_TIMEOUT = 45  # timeout (seconds)
 
 ORGANIC_SCORING_PERIOD = 28800  # scoring period in seconds

--- a/sturdy/constants.py
+++ b/sturdy/constants.py
@@ -32,11 +32,11 @@ QUERY_FREQUENCY = 600  # time in seconds between validator queries
 QUERY_TIMEOUT = 45  # timeout (seconds)
 
 ORGANIC_SCORING_PERIOD = 28800  # scoring period in seconds
-MIN_SCORING_PERIOD = 7200  # scoring period in seconds
-MAX_SCORING_PERIOD = 43200  # scoring period in seconds
-SCORING_PERIOD_STEP = 3600  # scoring period in seconds
+MIN_SCORING_PERIOD = 7200  # min. synthetic scoring period in seconds
+MAX_SCORING_PERIOD = 43200  # max. synthetic scoring period in seconds
+SCORING_PERIOD_STEP = 3600  # scoring period increments in seconds
 
-SCORING_WINDOW = 420  # scoring window (seconds)
+SCORING_WINDOW = 420  # scoring window
 
 TOTAL_ALLOC_THRESHOLD = 0.98
 ALLOCATION_SIMILARITY_THRESHOLD = 1e-4  # similarity threshold for plagiarism checking


### PR DESCRIPTION
Queries + syncing is done on a time-based frequency. It's effectively the same thing, will reduce the amount of requests valis send to the chain, and is just much simpler overall. 