### PR TITLE
Release/2.2.3

### DIFF
--- a/min_compute.yml
+++ b/min_compute.yml
@@ -10,7 +10,7 @@
 # Even then - storage isn't utilized very often - so disk performance won't really be a bottleneck vs, CPU, RAM, 
 # and network bandwidth.
 
-version: '2.2.2' # update this version key as needed, ideally should match your release version
+version: '2.2.3' # update this version key as needed, ideally should match your release version
 
 compute_spec:
 

--- a/sturdy/__init__.py
+++ b/sturdy/__init__.py
@@ -17,7 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the version of the template module.
-__version__ = "2.2.2"
+__version__ = "2.2.3"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 

--- a/sturdy/base/miner.py
+++ b/sturdy/base/miner.py
@@ -26,6 +26,7 @@ import bittensor as bt
 from web3 import Web3
 
 from sturdy.base.neuron import BaseNeuron
+from sturdy.constants import MINER_SYNC_FREQUENCY
 from sturdy.utils.config import add_miner_args
 from sturdy.utils.wandb import init_wandb_miner
 from dotenv import load_dotenv
@@ -123,18 +124,17 @@ class BaseMinerNeuron(BaseNeuron):
         # Start  starts the miner's axon, making it active on the network.
         self.axon.start()
 
-        bt.logging.info(f"Miner starting at block: {self.block}")
+        bt.logging.info("Miner starting...")
 
         # This loop maintains the miner's operations until intentionally stopped.
         try:
             while not self.should_exit:
-                while self.block - self.metagraph.last_update[self.uid] < self.config.neuron.epoch_length:
-                    # Wait before checking again.
-                    time.sleep(1)
+                # Wait before checking again.
+                time.sleep(MINER_SYNC_FREQUENCY)  # 12 seconds per block
 
-                    # Check if we should exit.
-                    if self.should_exit:
-                        break
+                # Check if we should exit.
+                if self.should_exit:
+                    break
 
                 # Sync metagraph and potentially set weights.
                 self.sync()

--- a/sturdy/base/validator.py
+++ b/sturdy/base/validator.py
@@ -161,7 +161,7 @@ class BaseValidatorNeuron(BaseNeuron):
         # Check that validator is registered on the network.
         self.sync()
 
-        bt.logging.info(f"Validator starting at block: {self.block}")
+        bt.logging.info(f"Validator starting...")
 
         # This loop maintains the validator's operations until intentionally stopped.
         try:
@@ -169,7 +169,7 @@ class BaseValidatorNeuron(BaseNeuron):
                 # Run multiple forwards concurrently - runs every QUERY_FREQUENCY seconds
                 current_time = time.time()
                 if current_time - self.last_query_time > QUERY_FREQUENCY:
-                    bt.logging.info(f"step({self.step}) block({self.block})")
+                    bt.logging.info(f"step({self.step})")
 
                     if self.config.organic:
                         future = asyncio.run_coroutine_threadsafe(self.concurrent_forward(), self.loop)
@@ -188,7 +188,6 @@ class BaseValidatorNeuron(BaseNeuron):
                                 f"miner_scores/score_uid_{uid}": float(score) for uid, score in enumerate(self.scores)
                             }
                             other_metrics = {
-                                "block": self.block,
                                 "validator_run_step": self.step,
                             }
                             sim_penalties = {
@@ -202,7 +201,7 @@ class BaseValidatorNeuron(BaseNeuron):
                             metrics_to_log.update(sim_penalties)
                             metrics_to_log.update(apys)
                             metrics_to_log.update(axon_times)
-                            self.wandb.log(metrics_to_log, step=self.block)
+                            self.wandb.log(metrics_to_log)
                             self.wandb_run_log_count += 1
                             bt.logging.info(
                                 f"wandb log count: {self.wandb_run_log_count} | \

--- a/sturdy/constants.py
+++ b/sturdy/constants.py
@@ -31,6 +31,8 @@ POOL_RESERVE_SIZE = int(100e18)  # 100
 QUERY_FREQUENCY = 600  # time in seconds between validator queries
 QUERY_TIMEOUT = 45  # timeout (seconds)
 
+MINER_SYNC_FREQUENCY = 300  # time in seconds between miner syncs
+
 ORGANIC_SCORING_PERIOD = 28800  # scoring period in seconds
 MIN_SCORING_PERIOD = 7200  # min. synthetic scoring period in seconds
 MAX_SCORING_PERIOD = 43200  # max. synthetic scoring period in seconds


### PR DESCRIPTION
- adds miner sync frequency constant and removes more unnecessary self.block calls
- wandb steps are no longer logged as blocks. who needed to use blocks as a unit of time anyway lol. timestamps are superior.