### PR TITLE
 Fix bug in calculating miner response time

### DIFF
--- a/sturdy/base/validator.py
+++ b/sturdy/base/validator.py
@@ -89,7 +89,7 @@ class BaseValidatorNeuron(BaseNeuron):
         self._stop_event = asyncio.Event()
         self._tasks = []
         self.last_query_time = 0
-        self.thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=16)
+        self.thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=self.config.validator.max_workers)
 
     def __del__(self):
         self.thread_pool.shutdown(wait=True)

--- a/sturdy/base/validator.py
+++ b/sturdy/base/validator.py
@@ -1,6 +1,7 @@
 import argparse
 import asyncio
 import copy
+import concurrent.futures
 import os
 import time
 
@@ -88,6 +89,10 @@ class BaseValidatorNeuron(BaseNeuron):
         self._stop_event = asyncio.Event()
         self._tasks = []
         self.last_query_time = 0
+        self.thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=16)
+
+    def __del__(self):
+        self.thread_pool.shutdown(wait=True)
 
     async def start(self) -> None:
         """Start validator tasks"""

--- a/sturdy/utils/config.py
+++ b/sturdy/utils/config.py
@@ -245,6 +245,13 @@ def add_validator_args(_cls, parser) -> None:
         default=DB_DIR,
     )
 
+    parser.add_argument(
+        "--validator.max_workers",
+        type=int,
+        help="maximum number of workers of validator thread pool for requesting miners",
+        default=None,
+    )
+
 
 def config(cls) -> bt.config:
     """

--- a/sturdy/validator/forward.py
+++ b/sturdy/validator/forward.py
@@ -42,6 +42,8 @@ from sturdy.validator.sql import (
     get_db_connection,
     log_allocations,
 )
+from sturdy.validator.utils.axon import query_single_axon
+from sturdy.validator.request import Request
 
 
 async def forward(self) -> Any:
@@ -131,29 +133,60 @@ def get_scoring_period(rng_gen: np.random.RandomState = None) -> int:
     )
 
 
-async def query_miner(
-    self,
-    synapse: bt.Synapse,
-    uid: str,
-    deserialize: bool = False,
-) -> bt.Synapse:
-    return await self.dendrite.forward(
-        axons=self.metagraph.axons[int(uid)],
-        synapse=synapse,
-        timeout=QUERY_TIMEOUT,
-        deserialize=deserialize,
-        streaming=False,
-    )
-
-
 async def query_multiple_miners(
     self,
     synapse: bt.Synapse,
     uids: list[str],
     deserialize: bool = False,
 ) -> list[bt.Synapse]:
-    uid_to_query_task = {uid: asyncio.create_task(query_miner(self, synapse, uid, deserialize)) for uid in uids}
-    return await asyncio.gather(*uid_to_query_task.values())
+    responses = []
+    for uid in uids:
+        request = prepare_single_request(self, int(uid), synapse.model_copy())
+        if request:
+            try:
+                task = asyncio.create_task(
+                    _process_single_request(self, request)
+                )
+                await task
+                request.synapse.dendrite.process_time = request.response_time
+                responses.append(request.synapse)
+            except Exception as e:
+                bt.logging.error(f"query_multiple_miners::Error in task for UID {uid}: {e}")
+                responses.append(None)
+        else:
+            bt.logging.error(f"query_multiple_miners::Error preparing request for UID {uid}")
+            responses.append(None)
+    return responses
+
+
+async def _process_single_request(self, request: Request) -> Request:
+        """
+        Process a single request and return the response.
+        """
+        try:
+            response = await asyncio.get_event_loop().run_in_executor(
+                self.thread_pool,
+                lambda: query_single_axon(self.dendrite, request),
+            )
+            response = await response
+        except Exception as e:
+            bt.logging.error(f"Error processing request for UID {request.uid}: {e}")
+        return request
+
+def prepare_single_request(self, uid: int, synapse: bt.Synapse) -> Request | None:
+        """
+        Prepare a single request to be sent to the miner.
+        """
+        try:
+            request = Request(
+                uid=uid,
+                axon=self.metagraph.axons[uid],
+                synapse=synapse,
+            )
+            return request
+        except Exception as e:
+            bt.logging.error(f"prepare_single_request::Error preparing request for UID {uid}: {e}")
+            return None
 
 
 async def query_and_score_miners(

--- a/sturdy/validator/forward.py
+++ b/sturdy/validator/forward.py
@@ -145,7 +145,7 @@ async def query_multiple_miners(
         if request:
             try:
                 task = asyncio.create_task(
-                    _process_single_request(self, request)
+                    process_single_request(self, request)
                 )
                 await task
                 request.synapse.dendrite.process_time = request.response_time
@@ -159,7 +159,7 @@ async def query_multiple_miners(
     return responses
 
 
-async def _process_single_request(self, request: Request) -> Request:
+async def process_single_request(self, request: Request) -> Request:
         """
         Process a single request and return the response.
         """

--- a/sturdy/validator/request.py
+++ b/sturdy/validator/request.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+import bittensor as bt
+
+
+@dataclass
+class Request:
+    """
+    A request to be sent to a miner.
+    """
+
+    uid: int
+    axon: bt.axon
+    response_time: float | None = None
+    deserialized: dict[str, object] | None = None
+    synapse: bt.Synapse | None = None
+    #save: bool = False

--- a/sturdy/validator/utils/axon.py
+++ b/sturdy/validator/utils/axon.py
@@ -1,0 +1,52 @@
+import traceback
+import bittensor as bt
+from aiohttp.client_exceptions import InvalidUrlClientError
+
+from sturdy.constants import (
+    QUERY_TIMEOUT,
+)
+from sturdy.validator.request import Request
+
+
+async def query_single_axon(dendrite: bt.dendrite, request: Request) -> Request | None:
+    """
+    Query a single axon with a request.
+
+    Args:
+        dendrite (bt.dendrite): The dendrite to use for querying.
+        request (Request): The request to send.
+
+    Returns:
+        Request | None: The request with results populated, or None if the request failed.
+    """
+
+    try:
+        result = await dendrite.call(
+            target_axon=request.axon,
+            synapse=request.synapse,
+            timeout=QUERY_TIMEOUT,
+            deserialize=False,
+        )
+
+        if not result:
+            return None
+        request.synapse = result
+        request.response_time = (
+            result.dendrite.process_time
+            if result.dendrite.process_time is not None
+            else QUERY_TIMEOUT
+        )
+
+        request.deserialized = result.deserialize()
+        return request
+
+    except InvalidUrlClientError:
+        bt.logging.error(
+            f"Ignoring UID as axon is not a valid URL: {request.uid}. {request.axon.ip}:{request.axon.port}"
+        )
+        return None
+
+    except Exception as e:
+        bt.logging.error(f"Failed to query axon for UID: {request.uid}. Error: {e}")
+        traceback.print_exc()
+        return None


### PR DESCRIPTION
**Background**
When Validators score Miners, response time is a critical metric. However, there is a significant issue in the current process where the calculation of miner response time is adversely affected by blocking delays on the Validator side:

- The process of sending requests experiences blocking, and the blocked time is inadvertently included in the calculated axon_time.
- Miners that are delayed due to this blocking are penalized with an increased axon_time, which affects their similarity score.
- Although the UIDs are randomly shuffled during task dispatch (see [PR #66](https://github.com/Sturdy-Subnet/sturdy-subnet/pull/66)), this does not mitigate the unfair impact on individual miners. We strongly recommend following the approach used in the subnet 02(https://github.com/inference-labs-inc/omron-subnet/blob/main/neurons/_validator/utils/axon.py) to exclude the Validator-side blocking time from the miner response time calculation.

**Changes**

- Create an independent request for each miner and compute a separate axon_time per request, ensuring that any delay due to scheduling is not included in the axon_time.
- Modify the calling logic in query_multiple_miners so that each miner’s task is timed independently.

**Testing**
In local-net environment, we have verified that each miner's response time is now recorded independently, and the timing inaccuracies have been resolved. Please see the attached screenshots for details.

**Before Changes**:
![image](https://github.com/user-attachments/assets/35dc1dca-8ed0-4f25-933f-e3826079bb05)

**After Changes**:
![image](https://github.com/user-attachments/assets/4c7eda0e-d23e-4e74-8436-19a2340be3af)

**Scope of Impact**:

- Only affects the miner task timing functionality and does not impact any other features.
- No additional documentation updates are required.