### PR TITLE
Release 2.2.8

### DIFF
--- a/min_compute.yml
+++ b/min_compute.yml
@@ -10,7 +10,7 @@
 # Even then - storage isn't utilized very often - so disk performance won't really be a bottleneck vs, CPU, RAM, 
 # and network bandwidth.
 
-version: '2.2.7' # update this version key as needed, ideally should match your release version
+version: '2.2.8' # update this version key as needed, ideally should match your release version
 
 compute_spec:
 

--- a/sturdy/__init__.py
+++ b/sturdy/__init__.py
@@ -17,7 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the version of the template module.
-__version__ = "2.2.7"
+__version__ = "2.2.8"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 

--- a/sturdy/algo.py
+++ b/sturdy/algo.py
@@ -59,6 +59,10 @@ def naive_algorithm(self: BaseMinerNeuron, synapse: AllocateAssets) -> dict:
                 supply_rates[pool.contract_address] = apy
                 supply_rate_sum += apy
 
+    if supply_rate_sum == 0:
+        # If all rates are zero, distribute remaining balance equally
+        equal_share = balance // len(pools)
+        return {pool_uid: minimums[pool_uid] + equal_share for pool_uid in pools}
     return {
         pool_uid: minimums[pool_uid] + math.floor((supply_rates[pool_uid] / supply_rate_sum) * balance) for pool_uid in pools
     }

--- a/sturdy/constants.py
+++ b/sturdy/constants.py
@@ -17,6 +17,13 @@ TOTAL_ALLOC_THRESHOLD = 0.98
 ALLOCATION_SIMILARITY_THRESHOLD = 1e-4  # similarity threshold for plagiarism checking
 APY_SIMILARITY_THRESHOLD = 1e-4
 
+
+# Constants for APY-based binning and rewards
+APY_BIN_THRESHOLD = 0.05  # 5% difference in APY to create new bin
+TOP_PERFORMERS_BONUS = 2.0  # Multiplier for top performing miners
+TOP_PERFORMERS_COUNT = 1  # Number of top performers to receive bonus
+
+
 NORM_EXP_POW = 16
 
 DB_DIR = "validator_database.db"  # default validator database dir

--- a/sturdy/constants.py
+++ b/sturdy/constants.py
@@ -15,14 +15,11 @@ SCORING_WINDOW = 420  # scoring window
 
 TOTAL_ALLOC_THRESHOLD = 0.98
 ALLOCATION_SIMILARITY_THRESHOLD = 1e-4  # similarity threshold for plagiarism checking
-APY_SIMILARITY_THRESHOLD = 1e-4
-
 
 # Constants for APY-based binning and rewards
 APY_BIN_THRESHOLD = 0.05  # 5% difference in APY to create new bin
 TOP_PERFORMERS_BONUS = 2.0  # Multiplier for top performing miners
 TOP_PERFORMERS_COUNT = 1  # Number of top performers to receive bonus
-
 
 NORM_EXP_POW = 16
 

--- a/sturdy/validator/apy_binning.py
+++ b/sturdy/validator/apy_binning.py
@@ -81,7 +81,8 @@ def calculate_base_rewards(bins: dict[int, list[str]], miner_uids: list[str]) ->
             idx = miner_uids.index(uid)  # Get index directly from list
             base_rewards[idx] = base_reward
 
-    return base_rewards
+    # Normalize base rewards - otherwise we'll have negative values
+    return normalize_rewards(base_rewards)
 
 
 def format_allocations(

--- a/sturdy/validator/apy_binning.py
+++ b/sturdy/validator/apy_binning.py
@@ -1,8 +1,16 @@
-import numpy as np
+import bittensor as bt
 import gmpy2
-from typing import Dict, List
+import numpy as np
 
-from sturdy.constants import APY_BIN_THRESHOLD, TOP_PERFORMERS_BONUS, TOP_PERFORMERS_COUNT
+from sturdy.constants import (
+    ALLOCATION_SIMILARITY_THRESHOLD,
+    APY_BIN_THRESHOLD,
+    NORM_EXP_POW,
+    TOP_PERFORMERS_BONUS,
+    TOP_PERFORMERS_COUNT,
+)
+from sturdy.pools import ChainBasedPoolModel
+from sturdy.protocol import AllocationsDict
 
 
 def create_apy_bins(apys: dict[str, int], bin_threshold: int = APY_BIN_THRESHOLD) -> dict[int, list[str]]:
@@ -47,55 +55,157 @@ def create_apy_bins(apys: dict[str, int], bin_threshold: int = APY_BIN_THRESHOLD
     return bins
 
 
-def calculate_bin_rewards(bins: Dict[int, List[str]], allocations: Dict[str, dict], total_assets: int) -> Dict[str, float]:
+def calculate_allocation_distance(alloc_a: np.ndarray, alloc_b: np.ndarray, total_assets: int) -> float:
+    """Calculate normalized Euclidean distance between two allocations."""
+    try:
+        squared_diff_sum = gmpy2.mpz(0)
+        for x, y in zip(alloc_a, alloc_b, strict=False):
+            diff = x - y
+            squared_diff_sum += diff * diff
+
+        total_assets_mpz = gmpy2.mpz(total_assets)
+        return float(gmpy2.sqrt(squared_diff_sum)) / float(total_assets_mpz * gmpy2.sqrt(2))
+    except Exception as e:
+        bt.logging.error(f"Error calculating distance: {e}")
+        return 1.0  # Return max distance on error
+
+
+def calculate_base_rewards(bins: dict[int, list[str]], miner_uids: list[str]) -> np.ndarray:
+    """Calculate base rewards for each miner based on their bin."""
+    base_rewards = np.zeros(len(miner_uids))
+
+    for bin_idx, bin_miners in bins.items():
+        # Higher bins get better base rewards
+        base_reward = 1.0 - (bin_idx * 0.1)
+        for uid in bin_miners:
+            idx = miner_uids.index(uid)  # Get index directly from list
+            base_rewards[idx] = base_reward
+
+    return base_rewards
+
+
+def format_allocations(
+    allocations: AllocationsDict,
+    assets_and_pools: dict,
+) -> AllocationsDict:
+    # TODO: better way to do this?
+    if allocations is None:
+        allocations = {}
+    allocs = allocations.copy()
+    pools = assets_and_pools["pools"]
+
+    # pad the allocations
+    for contract_addr in pools:
+        if contract_addr not in allocs:
+            allocs[contract_addr] = 0
+
+    # sort the allocations by contract address
+    return {contract_addr: allocs[contract_addr] for contract_addr in sorted(allocs.keys())}
+
+
+def apply_similarity_penalties(
+    bins: dict[int, list[str]],
+    allocations: dict[str, dict],
+    axon_times: dict[str, float],
+    assets_and_pools: int,
+    miner_uids: list[str],
+    similarity_threshold: float = ALLOCATION_SIMILARITY_THRESHOLD,
+) -> np.ndarray:
     """
-    Calculates rewards for miners within each bin based on allocation similarity.
+    Calculate similarity penalties within each bin, considering response times.
+    Only penalize miners who submitted similar allocations after another miner.
     """
-    rewards = {}
+    penalties = np.zeros(len(miner_uids))
+    uid_to_idx = {uid: idx for idx, uid in enumerate(miner_uids)}
 
-    for bin_idx, miner_uids in bins.items():
-        bin_size = len(miner_uids)
-        if bin_size == 0:
-            continue
+    total_assets = assets_and_pools["total_assets"]
+    allocs = format_allocations(allocations, assets_and_pools)
 
-        # Base reward for this bin (higher bins get higher base rewards)
-        base_reward = 1.0 - (bin_idx * 0.1)  # Decrease reward by 10% for each lower bin
+    for bin_miners in bins.values():
+        # Sort miners by axon time within each bin
+        sorted_miners = sorted(bin_miners, key=lambda uid: axon_times[uid])
 
-        # Calculate allocation similarities within bin
-        for uid_a in miner_uids:
-            alloc_a = np.array([gmpy2.mpz(val) for val in allocations[uid_a]["allocations"].values()], dtype=object)
+        for i, uid_a in enumerate(sorted_miners):
+            # Skip if allocation is None
+            if not allocs[uid_a] or allocs[uid_a].get("allocations") is None:
+                continue
 
-            # Start with base reward
-            similarity_penalty = 0
+            alloc_a = np.array([gmpy2.mpz(val) for val in allocs[uid_a]["allocations"].values()], dtype=object)
+            similar_count = 0
 
-            # Compare with other miners in same bin
-            for uid_b in miner_uids:
-                if uid_a != uid_b:
-                    alloc_b = np.array([gmpy2.mpz(val) for val in allocations[uid_b]["allocations"].values()], dtype=object)
+            # Only compare with miners that responde earlier
+            for uid_b in sorted_miners[:i]:
+                # Skip if allocation is None
+                if not allocs[uid_b] or allocs[uid_b].get("allocations") is None:
+                    continue
 
-                    # Calculate Euclidean distance with gmpy2
-                    squared_diff_sum = gmpy2.mpz(0)
-                    for x, y in zip(alloc_a, alloc_b, strict=False):
-                        diff = x - y
-                        squared_diff_sum += diff * diff
+                alloc_b = np.array([gmpy2.mpz(val) for val in allocs[uid_b]["allocations"].values()], dtype=object)
+                distance = calculate_allocation_distance(alloc_a, alloc_b, total_assets)
 
-                    # Calculate normalized distance
-                    total_assets_mpz = gmpy2.mpz(total_assets)
-                    diff = float(gmpy2.sqrt(squared_diff_sum)) / float(total_assets_mpz * gmpy2.sqrt(2))
-                    similarity_penalty += (1 - diff) / (bin_size - 1)
+                if distance < similarity_threshold:
+                    similar_count += 1
 
-            # Final reward calculation
-            rewards[uid_a] = base_reward * (1 - similarity_penalty)
+            if similar_count > 0 and i > 0:
+                penalties[uid_to_idx[uid_a]] = similar_count / i
+
+    return penalties
+
+
+def apply_top_performer_bonus(rewards: np.ndarray) -> np.ndarray:
+    """Apply bonus multiplier to top performing miners."""
+    final_rewards = rewards.copy()
+
+    # Get indices of top performers
+    top_indices = np.argsort(rewards)[-TOP_PERFORMERS_COUNT:]
 
     # Apply bonus to top performers
-    sorted_rewards = sorted(rewards.items(), key=lambda x: x[1], reverse=True)
-    for i in range(min(TOP_PERFORMERS_COUNT, len(sorted_rewards))):
-        uid = sorted_rewards[i][0]
-        rewards[uid] *= TOP_PERFORMERS_BONUS
+    final_rewards[top_indices] *= TOP_PERFORMERS_BONUS
 
-    # Normalize rewards
-    max_reward = max(rewards.values())
+    return final_rewards
+
+
+def exponentiate_rewards(rewards: np.ndarray) -> np.ndarray:
+    """Apply exponential transformation to rewards."""
+    return np.pow(rewards, NORM_EXP_POW)
+
+
+def normalize_rewards(rewards: np.ndarray) -> np.ndarray:
+    """Normalize rewards to [0, 1] range."""
+    max_reward = np.max(rewards)
     if max_reward > 0:
-        rewards = {uid: r / max_reward for uid, r in rewards.items()}
-
+        return rewards / max_reward
     return rewards
+
+
+def calculate_bin_rewards(
+    bins: dict[int, list[str]],
+    allocations: dict[str, dict],
+    assets_and_pools: dict[str, dict[str, ChainBasedPoolModel] | int],
+    axon_times: dict[str, float],
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Calculate rewards for miners within each bin, considering APY performance,
+    allocation uniqueness, and response times.
+    """
+    # Get list of miner UIDs in original order
+    miner_uids = list(allocations.keys())
+
+    # Calculate base rewards based on bin membership
+    rewards = calculate_base_rewards(bins, miner_uids)
+
+    # Apply penalties for similar allocations (only to later responders)
+    penalties = apply_similarity_penalties(bins, allocations, axon_times, assets_and_pools, miner_uids)
+
+    # Apply penalties to rewards
+    rewards *= 1 - penalties
+
+    # TODO: Apply exponential transformation? (disabled for now)
+    # rewards = exponentiate_rewards(rewards)  # noqa: ERA001
+
+    # Apply bonus to top performers after exponential transformation
+    rewards = apply_top_performer_bonus(rewards)
+
+    # Normalize final rewards
+    rewards = normalize_rewards(rewards)
+
+    return rewards, penalties

--- a/sturdy/validator/apy_binning.py
+++ b/sturdy/validator/apy_binning.py
@@ -1,0 +1,101 @@
+import numpy as np
+import gmpy2
+from typing import Dict, List
+
+from sturdy.constants import APY_BIN_THRESHOLD, TOP_PERFORMERS_BONUS, TOP_PERFORMERS_COUNT
+
+
+def create_apy_bins(apys: dict[str, int], bin_threshold: int = APY_BIN_THRESHOLD) -> dict[int, list[str]]:
+    """
+    Creates bins of miners based on their APY values using relative differences.
+
+    Args:
+        apys: Dictionary mapping miner UIDs to their APY values
+        bin_threshold: Threshold for creating new bins (default: APY_BIN_THRESHOLD)
+
+    Returns:
+        Dictionary mapping bin indices to lists of miner UIDs
+    """
+    # Sort APYs in descending order
+    sorted_items = sorted(apys.items(), key=lambda x: x[1], reverse=True)
+
+    bins: dict[int, list[str]] = {}
+    current_bin = 0
+
+    if not sorted_items:
+        return bins
+
+    # Initialize first bin with highest APY miner
+    bins[current_bin] = [sorted_items[0][0]]
+    current_base_apy = sorted_items[0][1]
+
+    # Assign miners to bins based on APY differences
+    for uid, apy in sorted_items[1:]:
+        # Calculate relative difference from current bin's base APY
+        # Using relative difference: (a - b) / max(|a|, |b|)
+        relative_diff = abs(apy - current_base_apy) / max(abs(current_base_apy), abs(apy), 1)
+
+        if relative_diff > (bin_threshold):  # Convert threshold to decimal
+            # Create new bin
+            current_bin += 1
+            current_base_apy = apy
+            bins[current_bin] = [uid]
+        else:
+            # Add to current bin
+            bins[current_bin].append(uid)
+
+    return bins
+
+
+def calculate_bin_rewards(bins: Dict[int, List[str]], allocations: Dict[str, dict], total_assets: int) -> Dict[str, float]:
+    """
+    Calculates rewards for miners within each bin based on allocation similarity.
+    """
+    rewards = {}
+
+    for bin_idx, miner_uids in bins.items():
+        bin_size = len(miner_uids)
+        if bin_size == 0:
+            continue
+
+        # Base reward for this bin (higher bins get higher base rewards)
+        base_reward = 1.0 - (bin_idx * 0.1)  # Decrease reward by 10% for each lower bin
+
+        # Calculate allocation similarities within bin
+        for uid_a in miner_uids:
+            alloc_a = np.array([gmpy2.mpz(val) for val in allocations[uid_a]["allocations"].values()], dtype=object)
+
+            # Start with base reward
+            similarity_penalty = 0
+
+            # Compare with other miners in same bin
+            for uid_b in miner_uids:
+                if uid_a != uid_b:
+                    alloc_b = np.array([gmpy2.mpz(val) for val in allocations[uid_b]["allocations"].values()], dtype=object)
+
+                    # Calculate Euclidean distance with gmpy2
+                    squared_diff_sum = gmpy2.mpz(0)
+                    for x, y in zip(alloc_a, alloc_b, strict=False):
+                        diff = x - y
+                        squared_diff_sum += diff * diff
+
+                    # Calculate normalized distance
+                    total_assets_mpz = gmpy2.mpz(total_assets)
+                    diff = float(gmpy2.sqrt(squared_diff_sum)) / float(total_assets_mpz * gmpy2.sqrt(2))
+                    similarity_penalty += (1 - diff) / (bin_size - 1)
+
+            # Final reward calculation
+            rewards[uid_a] = base_reward * (1 - similarity_penalty)
+
+    # Apply bonus to top performers
+    sorted_rewards = sorted(rewards.items(), key=lambda x: x[1], reverse=True)
+    for i in range(min(TOP_PERFORMERS_COUNT, len(sorted_rewards))):
+        uid = sorted_rewards[i][0]
+        rewards[uid] *= TOP_PERFORMERS_BONUS
+
+    # Normalize rewards
+    max_reward = max(rewards.values())
+    if max_reward > 0:
+        rewards = {uid: r / max_reward for uid, r in rewards.items()}
+
+    return rewards

--- a/sturdy/validator/reward.py
+++ b/sturdy/validator/reward.py
@@ -17,20 +17,18 @@
 # DEALINGS IN THE SOFTWARE.
 
 import json
-from typing import Any, cast
+from typing import cast
 
 import bittensor as bt
-import gmpy2
-import numpy as np
 import numpy.typing as npt
 
-from sturdy.constants import ALLOCATION_SIMILARITY_THRESHOLD, APY_SIMILARITY_THRESHOLD, NORM_EXP_POW, QUERY_TIMEOUT
+from sturdy.constants import QUERY_TIMEOUT
 from sturdy.pools import POOL_TYPES, ChainBasedPoolModel, PoolFactory, check_allocations
 from sturdy.protocol import AllocationsDict, AllocInfo
 from sturdy.utils.ethmath import wei_div
 from sturdy.utils.misc import get_scoring_period_length
+from sturdy.validator.apy_binning import calculate_bin_rewards, create_apy_bins
 from sturdy.validator.sql import get_db_connection, get_miner_responses, get_request_info
-from sturdy.validator.apy_binning import create_apy_bins, calculate_bin_rewards
 
 
 def get_response_times(uids: list[str], responses, timeout: float) -> dict[str, float]:
@@ -64,237 +62,6 @@ def get_response_times(uids: list[str], responses, timeout: float) -> dict[str, 
     }
 
 
-def format_allocations(
-    allocations: AllocationsDict,
-    assets_and_pools: dict,
-) -> AllocationsDict:
-    # TODO: better way to do this?
-    if allocations is None:
-        allocations = {}
-    allocs = allocations.copy()
-    pools: Any = assets_and_pools["pools"]
-
-    # pad the allocations
-    for contract_addr in pools:
-        if contract_addr not in allocs:
-            allocs[contract_addr] = 0
-
-    # sort the allocations by contract address
-    return {contract_addr: allocs[contract_addr] for contract_addr in sorted(allocs.keys())}
-
-
-def normalize_exp(apys_and_allocations: AllocationsDict, epsilon: float = 1e-8) -> npt.NDArray:
-    raw_apys = {uid: apys_and_allocations[uid]["apy"] for uid in apys_and_allocations}
-
-    if len(raw_apys) <= 1:
-        return np.zeros(len(raw_apys))
-
-    apys = np.array(list(raw_apys.values()), dtype=np.float32)
-    normed = (apys - apys.min()) / (apys.max() - apys.min() + epsilon)
-
-    return np.pow(normed, NORM_EXP_POW)
-
-
-def calculate_penalties(
-    allocation_similarity_matrix: dict[str, dict[str, float]],
-    apy_similarity_matrix: dict[str, dict[str, float]],
-    axon_times: dict[str, float],
-    allocation_similarity_threshold: float = ALLOCATION_SIMILARITY_THRESHOLD,
-    apy_similarity_threshold: float = APY_SIMILARITY_THRESHOLD,
-) -> dict[str, int]:
-    penalties = {miner: 0 for miner in allocation_similarity_matrix}
-
-    for miner_a in allocation_similarity_matrix:
-        allocation_similarities = allocation_similarity_matrix[miner_a]
-        apy_similarities = apy_similarity_matrix[miner_a]
-        for miner_b in allocation_similarities:
-            allocation_similarity = allocation_similarities[miner_b]
-            apy_similarity = apy_similarities[miner_b]
-            if (
-                allocation_similarity <= allocation_similarity_threshold
-                and apy_similarity <= apy_similarity_threshold
-                and axon_times[miner_a] <= axon_times[miner_b]
-            ):
-                penalties[miner_b] += 1
-
-    return penalties
-
-
-def calculate_rewards_with_adjusted_penalties(miners, rewards_apy, penalties) -> npt.NDArray:
-    rewards = np.zeros(len(miners))
-    max_penalty = max(penalties.values())
-    if max_penalty == 0:
-        return rewards_apy
-
-    for idx, miner_id in enumerate(miners):
-        # Calculate penalty adjustment
-        penalty_factor = (max_penalty - penalties[miner_id]) / max_penalty
-
-        # Calculate the final reward
-        reward = rewards_apy[idx] * penalty_factor
-        rewards[idx] = reward
-
-    return rewards
-
-
-def get_distance(alloc_a: npt.NDArray, alloc_b: npt.NDArray, total_assets: int) -> float:
-    try:
-        diff = alloc_a - alloc_b
-        norm = gmpy2.sqrt(sum(x**2 for x in diff))
-        return norm / gmpy2.sqrt(2 * total_assets**2)
-    except Exception as e:
-        bt.logging.error("Could not obtain distance - default to 69.0")
-        bt.logging.error(e)
-        return 69.0
-
-
-def get_allocation_similarity_matrix(
-    apys_and_allocations: dict[str, dict[str, AllocationsDict | int]],
-    assets_and_pools: dict[str, dict[str, ChainBasedPoolModel] | int],
-) -> dict[str, dict[str, float]]:
-    """
-    Calculates the similarity matrix for the allocation strategies of miners using normalized Euclidean distance.
-
-    This function computes a similarity matrix based on the Euclidean distance between the allocation vectors of miners,
-    normalized by the maximum possible distance in the given asset space. Each miner's allocation is compared with every
-    other miner's allocation, resulting in a matrix where each element (i, j) represents the normalized Euclidean distance
-    between the allocations of miner_i and miner_j.
-
-    The similarity metric is scaled between 0 and 1, where 0 indicates identical allocations and 1 indicates the maximum
-    possible distance between the allocation 'vectors'.
-
-    Args:
-        apys_and_allocations (dict[str, dict[str, Union[AllocationsDict, int]]]):
-            A dictionary containing the APY and allocation strategies for each miner. The keys are miner identifiers,
-            and the values are dictionaries with their respective allocations and APYs.
-        assets_and_pools (dict[str, Union[AllocationsDict, int]]):
-            A dictionary representing the assets available to the miner as well as the pools they can allocate to
-
-    Returns:
-        dict[str, dict[str, float]]:
-            A nested dictionary where each key is a miner identifier, and the value is another dictionary containing the
-            normalized Euclidean distances to every other miner. The distances are scaled between 0 and 1.
-    """
-
-    similarity_matrix = {}
-    total_assets = cast(int, assets_and_pools["total_assets"])
-    for miner_a, info_a in apys_and_allocations.items():
-        _alloc_a = cast(AllocationsDict, info_a["allocations"])
-        alloc_a = np.array(
-            [gmpy2.mpz(x) for x in list(format_allocations(_alloc_a, assets_and_pools).values())],
-        )
-        similarity_matrix[miner_a] = {}
-        for miner_b, info_b in apys_and_allocations.items():
-            if miner_a != miner_b:
-                _alloc_b = cast(AllocationsDict, info_b["allocations"])
-                if _alloc_a is None or _alloc_b is None:
-                    similarity_matrix[miner_a][miner_b] = float("inf")
-                    continue
-                alloc_b = np.array(
-                    [gmpy2.mpz(x) for x in list(format_allocations(_alloc_b, assets_and_pools).values())],
-                )
-                similarity_matrix[miner_a][miner_b] = get_distance(alloc_a, alloc_b, total_assets)
-
-    return similarity_matrix
-
-
-def get_apy_similarity_matrix(
-    apys_and_allocations: dict[str, dict[str, AllocationsDict | int]],
-) -> dict[str, dict[str, float]]:
-    """
-    Calculates the similarity matrix for the allocation strategies of miners' APY using normalized Euclidean distance.
-
-    This function computes a similarity matrix based on the Euclidean distance between the allocation vectors of miners,
-    normalized by the maximum possible distance in the given asset space. Each miner's allocation is compared with every
-    other miner's allocation, resulting in a matrix where each element (i, j) represents the normalized Euclidean distance
-    between the allocations of miner_i and miner_j.
-
-    The similarity metric is scaled between 0 and 1, where 0 indicates identical allocations and 1 indicates the maximum
-    possible distance between the allocation 'vectors'.
-
-    Args:
-        apys_and_allocations (dict[str, dict[str, Union[AllocationsDict, int]]]):
-            A dictionary containing the APY and allocation strategies for each miner. The keys are miner identifiers,
-            and the values are dictionaries with their respective allocations and APYs.
-
-    Returns:
-        dict[str, dict[str, float]]:
-            A nested dictionary where each key is a miner identifier, and the value is another dictionary containing the
-            normalized Euclidean distances to every other miner. The distances are scaled between 0 and 1.
-    """
-
-    similarity_matrix = {}
-
-    for miner_a, info_a in apys_and_allocations.items():
-        apy_a = cast(int, info_a["apy"])
-        apy_a = np.array([gmpy2.mpz(apy_a)], dtype=object)
-        similarity_matrix[miner_a] = {}
-        for miner_b, info_b in apys_and_allocations.items():
-            if miner_a != miner_b:
-                apy_b = cast(int, info_b["apy"])
-                apy_b = np.array([gmpy2.mpz(apy_b)], dtype=object)
-                similarity_matrix[miner_a][miner_b] = get_distance(apy_a, apy_b, max(apy_a, apy_b)[0])  # Max scaling
-
-    return similarity_matrix
-
-
-def adjust_rewards_for_plagiarism(
-    self,
-    rewards_apy: npt.NDArray,
-    apys_and_allocations: dict[str, dict[str, AllocationsDict | int]],
-    assets_and_pools: dict[str, dict[str, ChainBasedPoolModel] | int],
-    uids: list,
-    axon_times: dict[str, float],
-    allocation_similarity_threshold: float = ALLOCATION_SIMILARITY_THRESHOLD,
-    apy_similarity_threshold: float = APY_SIMILARITY_THRESHOLD,
-) -> npt.NDArray:
-    """
-    Adjusts the annual percentage yield (APY) rewards for miners based on the similarity of their allocations
-    to others and their arrival times, penalizing plagiarized or overly similar strategies.
-
-    This function calculates the similarity between each pair of miners' allocation strategies and applies a penalty
-    to those whose allocations are too similar to others, considering the order in which they arrived. Miners who
-    arrived earlier with unique strategies are given preference, and those with similar strategies arriving later
-    are penalized. The final APY rewards are adjusted accordingly.
-
-    Args:
-        rewards_apy (torch.Tensor): The initial APY rewards for the miners, before adjustments.
-        apys_and_allocations (dict[str, dict[str, Union[AllocationsDict, int]]]):
-            A dictionary containing APY values and allocation strategies for each miner. The keys are miner identifiers,
-            and the values are dictionaries that include their allocations and APYs.
-        assets_and_pools (dict[str, Union[dict[str, int], int]]):
-            A dictionary representing the available assets and their corresponding pools.
-        uids (List): A list of unique identifiers for the miners.
-        axon_times (dict[str, float]): A dictionary that tracks the arrival times of each miner, with the keys being
-            miner identifiers and the values being their arrival times. Earlier times are lower values.
-
-    Returns:
-        torch.Tensor: The adjusted APY rewards for the miners, accounting for penalties due to similarity with
-        other miners' strategies and their arrival times.
-    Notes:
-        - This function relies on the helper functions `calculate_penalties` and `calculate_rewards_with_adjusted_penalties`
-          which are defined separately.
-        - The `format_allocations` function used in the similarity calculation converts the allocation dictionaries
-          to a consistent format suitable for comparison.
-    """
-    # Step 1: Calculate pairwise similarity (e.g., using Euclidean distance)
-    allocation_similarity_matrix = get_allocation_similarity_matrix(apys_and_allocations, assets_and_pools)
-    apy_similarity_matrix = get_apy_similarity_matrix(apys_and_allocations)
-
-    # Step 2: Apply penalties considering axon times
-    penalties = calculate_penalties(
-        allocation_similarity_matrix,
-        apy_similarity_matrix,
-        axon_times,
-        allocation_similarity_threshold,
-        apy_similarity_threshold,
-    )
-    self.similarity_penalties = penalties
-
-    # Step 3: Calculate final rewards with adjusted penalties
-    return calculate_rewards_with_adjusted_penalties(uids, rewards_apy, penalties)
-
-
 def _get_rewards(
     self,
     apys_and_allocations: dict[str, dict[str, AllocationsDict | int]],
@@ -312,12 +79,12 @@ def _get_rewards(
     apy_bins = create_apy_bins(apys)
 
     # Calculate rewards based on bins and allocation similarity
-    rewards = calculate_bin_rewards(apy_bins, apys_and_allocations, cast(int, assets_and_pools["total_assets"]))
+    rewards, penalties = calculate_bin_rewards(apy_bins, apys_and_allocations, assets_and_pools, axon_times)
 
-    # Convert rewards to numpy array in correct order
-    rewards_array = np.array([rewards.get(uid, 0.0) for uid in uids])
+    # Store penalties for logging/debugging
+    self.similarity_penalties = {uid: penalties[i] for i, uid in enumerate(uids)}
 
-    return rewards_array
+    return rewards
 
 
 def annualized_yield_pct(

--- a/tests/unit/validator/test_reward_helpers.py
+++ b/tests/unit/validator/test_reward_helpers.py
@@ -11,155 +11,24 @@ from sturdy.algo import naive_algorithm
 from sturdy.pool_registry.pool_registry import POOL_REGISTRY
 from sturdy.pools import *
 from sturdy.protocol import REQUEST_TYPES, AllocateAssets
-from sturdy.validator.apy_binning import calculate_bin_rewards, create_apy_bins
-from sturdy.validator.reward import (
-    adjust_rewards_for_plagiarism,
-    annualized_yield_pct,
-    calculate_penalties,
-    calculate_rewards_with_adjusted_penalties,
+from sturdy.validator.apy_binning import (
+    apply_similarity_penalties,
+    apply_top_performer_bonus,
+    calculate_allocation_distance,
+    calculate_base_rewards,
+    calculate_bin_rewards,
+    create_apy_bins,
     format_allocations,
-    get_allocation_similarity_matrix,
-    get_apy_similarity_matrix,
-    get_distance,
-    normalize_exp,
+)
+from sturdy.validator.reward import (
+    annualized_yield_pct,
 )
 
 load_dotenv()
 WEB3_PROVIDER_URL = os.getenv("WEB3_PROVIDER_URL")
 
-BEEF = "0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF"
 
-
-class TestGetDistance(unittest.TestCase):
-    def test_identical_allocations(self) -> None:
-        # Test case where allocations are identical, expecting 0 distance
-        alloc_a = np.array([100, 200, 300], dtype=object)
-        alloc_b = np.array([100, 200, 300], dtype=object)
-        total_assets = 600
-        self.assertEqual(get_distance(alloc_a, alloc_b, total_assets), 0.0)
-
-    def test_positive_allocations(self) -> None:
-        # Test case with positive values, expecting a non-zero distance
-        alloc_a = np.array([100, 200, 300], dtype=object)
-        alloc_b = np.array([50, 150, 250], dtype=object)
-        total_assets = 600
-        expected_distance = gmpy2.sqrt(sum((x - y) ** 2 for x, y in zip(alloc_a, alloc_b, strict=False))) / gmpy2.sqrt(
-            float(2 * total_assets**2)
-        )
-        self.assertAlmostEqual(float(get_distance(alloc_a, alloc_b, total_assets)), float(expected_distance), places=6)
-
-    def test_zero_allocations(self) -> None:
-        # Test case where one allocation is all zeros
-        alloc_a = np.array([100, 200, 300], dtype=object)
-        alloc_b = np.array([0, 0, 0], dtype=object)
-        total_assets = 600
-        expected_distance = gmpy2.sqrt(sum(x**2 for x in alloc_a)) / gmpy2.sqrt(float(2 * total_assets**2))
-        self.assertAlmostEqual(float(get_distance(alloc_a, alloc_b, total_assets)), float(expected_distance), places=6)
-
-    def test_large_numbers(self) -> None:
-        # Test case with very large numbers to ensure precision
-        alloc_a = np.array([2**100, 2**100, 2**100], dtype=object)
-        alloc_b = np.array([2**99, 2**99, 2**99], dtype=object)
-        total_assets = 2**100
-        expected_distance = gmpy2.sqrt(sum((x - y) ** 2 for x, y in zip(alloc_a, alloc_b, strict=False))) / gmpy2.sqrt(
-            float(2 * total_assets**2)
-        )
-        self.assertAlmostEqual(float(get_distance(alloc_a, alloc_b, total_assets)), float(expected_distance), places=6)
-
-    def test_large_numbers_gap(self) -> None:
-        # Test case with very large numbers to ensure precision
-        alloc_a = np.array([1e100, 1e100, 1e100], dtype=object)
-        alloc_b = np.array([1e21, 1e21, 1e21], dtype=object)
-        total_assets = 1e101
-        expected_distance = gmpy2.sqrt(sum((x - y) ** 2 for x, y in zip(alloc_a, alloc_b, strict=False))) / gmpy2.sqrt(
-            float(2 * total_assets**2)
-        )
-        self.assertAlmostEqual(float(get_distance(alloc_a, alloc_b, total_assets)), float(expected_distance), places=6)
-
-    def test_different_lengths(self) -> None:
-        # Test case with differing lengths should raise an error, and return 69.0
-        alloc_a = np.array([100, 200], dtype=object)
-        alloc_b = np.array([100, 200, 300], dtype=object)
-        total_assets = 600
-        self.assertEqual(69.0, get_distance(alloc_a, alloc_b, total_assets))
-
-
-class TestDynamicNormalizeZScore(unittest.TestCase):
-    def test_basic_normalization(self) -> None:
-        # Test a simple AllocationsDict with large values
-        apys_and_allocations = {"1": {"apy": 1e16}, "2": {"apy": 2e16}, "3": {"apy": 3e16}, "4": {"apy": 4e16}}
-        normalized = normalize_exp(apys_and_allocations)
-
-        # Check if output is normalized between 0 and 1
-        self.assertAlmostEqual(normalized.min().item(), 0.0, places=5)
-        self.assertAlmostEqual(normalized.max().item(), 1.0, places=5)
-
-    def test_with_low_outliers(self) -> None:
-        # Test with low outliers in AllocationsDict
-        apys_and_allocations = {
-            "1": {"apy": 1e16},
-            "2": {"apy": 1e16},
-            "3": {"apy": 1e16},
-            "4": {"apy": 5e16},
-            "5": {"apy": 1e17},
-        }
-        normalized = normalize_exp(apys_and_allocations)
-
-        # Check that outliers don't affect the overall normalization
-        self.assertAlmostEqual(normalized.min().item(), 0.0, places=5)
-        self.assertAlmostEqual(normalized.max().item(), 1.0, places=5)
-
-    def test_with_high_outliers(self) -> None:
-        # Test with high outliers in AllocationsDict
-        apys_and_allocations = {
-            "1": {"apy": 5e16},
-            "2": {"apy": 6e16},
-            "3": {"apy": 7e16},
-            "4": {"apy": 1e17},
-            "5": {"apy": 2e17},
-        }
-        normalized = normalize_exp(apys_and_allocations)
-
-        # Check that the function correctly handles high outliers
-        self.assertAlmostEqual(normalized.min().item(), 0.0, places=5)
-        self.assertAlmostEqual(normalized.max().item(), 1.0, places=5)
-
-    def test_uniform_values(self) -> None:
-        # Test where all values are the same
-        apys_and_allocations = {"1": {"apy": 1e16}, "2": {"apy": 1e16}, "3": {"apy": 1e16}, "4": {"apy": 1e16}}
-        normalized = normalize_exp(apys_and_allocations)
-
-        # If all values are the same, the output should also be uniform (or handle gracefully)
-        self.assertTrue(
-            np.allclose(normalized, np.zeros_like(np.array([v["apy"] for v in apys_and_allocations.values()])), atol=1e-8)
-        )
-
-    def test_low_variance(self) -> None:
-        # Test with low variance data (values are close to each other)
-        apys_and_allocations = {
-            "1": {"apy": 1e16},
-            "2": {"apy": 1.01e16},
-            "3": {"apy": 1.02e16},
-            "4": {"apy": 1.03e16},
-            "5": {"apy": 1.04e16},
-        }
-        normalized = normalize_exp(apys_and_allocations)
-
-        # Check if normalization happens correctly
-        self.assertAlmostEqual(normalized.min().item(), 0.0, places=5)
-        self.assertAlmostEqual(normalized.max().item(), 1.0, places=5)
-
-    def test_high_variance(self) -> None:
-        # Test with high variance data
-        apys_and_allocations = {"1": {"apy": 1e16}, "2": {"apy": 1e17}, "3": {"apy": 5e17}, "4": {"apy": 1e18}}
-        normalized = normalize_exp(apys_and_allocations)
-
-        # Ensure that the normalization works even with high variance
-        self.assertAlmostEqual(normalized.min().item(), 0.0, places=5)
-        self.assertAlmostEqual(normalized.max().item(), 1.0, places=5)
-
-
-class TestRewardFunctions(unittest.TestCase):
+class TestCheckAllocations(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         # runs tests on local mainnet fork at block: 20233401
@@ -460,483 +329,6 @@ class TestRewardFunctions(unittest.TestCase):
         result = check_allocations(assets_and_pools, allocations, alloc_threshold=0)
         self.assertTrue(result)
 
-    def test_format_allocations(self) -> None:
-        allocations = {"1": int(5e18), "2": int(3e18)}
-        assets_and_pools = {
-            "pools": {
-                "1": {"reserve_size": 1000},
-                "2": {"reserve_size": 1000},
-                "3": {"reserve_size": 1000},
-            }
-        }
-
-        expected_output = {"1": 5e18, "2": 3e18, "3": 0}
-        result = format_allocations(allocations, assets_and_pools)
-
-        self.assertEqual(result, expected_output)
-
-    def test_format_allocations_no_pools(self) -> None:
-        allocations = {"1": int(5e18), "2": int(3e18)}
-        assets_and_pools = {"pools": {}}
-
-        expected_output = {"1": 5e18, "2": 3e18}
-        result = format_allocations(allocations, assets_and_pools)
-
-        self.assertEqual(result, expected_output)
-
-    def test_format_allocations_empty(self) -> None:
-        allocations = {}
-        assets_and_pools = {
-            "pools": {
-                "1": {"reserve_size": 1000},
-                "2": {"reserve_size": 1000},
-            }
-        }
-
-        expected_output = {"1": 0, "2": 0}
-        result = format_allocations(allocations, assets_and_pools)
-
-        self.assertEqual(result, expected_output)
-
-    def test_get_allocation_similarity_matrix(self) -> None:
-        apys_and_allocations = {
-            "miner_1": {
-                "apy": int(0.05e18),
-                "allocations": {"pool_1": 30e18, "pool_2": 20e18},
-            },
-            "miner_2": {
-                "apy": int(0.04e18),
-                "allocations": {"pool_1": 40e18, "pool_2": 10e18},
-            },
-            "miner_3": {
-                "apy": int(0.06e18),
-                "allocations": {"pool_1": 30e18, "pool_2": 20e18},
-            },
-        }
-        assets_and_pools = {
-            "pools": {
-                "pool_1": {"reserve_size": 100e18},
-                "pool_2": {"reserve_size": 100e18},
-            },
-            "total_assets": 10e18,
-        }
-
-        total_assets = assets_and_pools["total_assets"]
-
-        expected_similarity_matrix = {
-            "miner_2": {
-                "miner_1": get_distance(
-                    np.array([gmpy2.mpz(40e18), gmpy2.mpz(10e18)], dtype=object),
-                    np.array([gmpy2.mpz(30e18), gmpy2.mpz(20e18)], dtype=object),
-                    total_assets,
-                ),
-                "miner_3": get_distance(
-                    np.array([gmpy2.mpz(40e18), gmpy2.mpz(10e18)], dtype=object),
-                    np.array([gmpy2.mpz(30e18), gmpy2.mpz(20e18)], dtype=object),
-                    total_assets,
-                ),
-            },
-            "miner_1": {
-                "miner_2": get_distance(
-                    np.array([gmpy2.mpz(30e18), gmpy2.mpz(20e18)], dtype=object),
-                    np.array([gmpy2.mpz(40e18), gmpy2.mpz(10e18)], dtype=object),
-                    total_assets,
-                ),
-                "miner_3": get_distance(
-                    np.array([gmpy2.mpz(30e18), gmpy2.mpz(20e18)], dtype=object),
-                    np.array([gmpy2.mpz(30e18), gmpy2.mpz(20e18)], dtype=object),
-                    total_assets,
-                ),
-            },
-            "miner_3": {
-                "miner_1": get_distance(
-                    np.array([gmpy2.mpz(30e18), gmpy2.mpz(20e18)], dtype=object),
-                    np.array([gmpy2.mpz(30e18), gmpy2.mpz(20e18)], dtype=object),
-                    total_assets,
-                ),
-                "miner_2": get_distance(
-                    np.array([gmpy2.mpz(30e18), gmpy2.mpz(20e18)], dtype=object),
-                    np.array([gmpy2.mpz(40e18), gmpy2.mpz(10e18)], dtype=object),
-                    total_assets,
-                ),
-            },
-        }
-
-        result = get_allocation_similarity_matrix(apys_and_allocations, assets_and_pools)
-
-        for miner_a in expected_similarity_matrix:
-            for miner_b in expected_similarity_matrix[miner_a]:
-                self.assertAlmostEqual(
-                    result[miner_a][miner_b],
-                    expected_similarity_matrix[miner_a][miner_b],
-                    places=5,
-                )
-
-    def test_get_apy_similarity_matrix(self) -> None:
-        apys_and_allocations = {
-            "miner_1": {
-                "apy": int(0.05e18),
-                "allocations": {"pool_1": 30e18, "pool_2": 20e18},
-            },
-            "miner_2": {
-                "apy": int(0.04e18),
-                "allocations": {"pool_1": 40e18, "pool_2": 10e18},
-            },
-            "miner_3": {
-                "apy": int(0.06e18),
-                "allocations": {"pool_1": 30e18, "pool_2": 20e18},
-            },
-        }
-
-        expected_similarity_matrix = {
-            "miner_1": {
-                "miner_2": get_distance(
-                    np.array([gmpy2.mpz(0.05e18)], dtype=object),
-                    np.array([gmpy2.mpz(0.04e18)], dtype=object),
-                    gmpy2.mpz(0.05e18),
-                ),
-                "miner_3": get_distance(
-                    np.array([gmpy2.mpz(0.05e18)], dtype=object),
-                    np.array([gmpy2.mpz(0.06e18)], dtype=object),
-                    gmpy2.mpz(0.06e18),
-                ),
-            },
-            "miner_2": {
-                "miner_1": get_distance(
-                    np.array([gmpy2.mpz(0.04e18)], dtype=object),
-                    np.array([gmpy2.mpz(0.05e18)], dtype=object),
-                    gmpy2.mpz(0.05e18),
-                ),
-                "miner_3": get_distance(
-                    np.array([gmpy2.mpz(0.04e18)], dtype=object),
-                    np.array([gmpy2.mpz(0.06e18)], dtype=object),
-                    gmpy2.mpz(0.06e18),
-                ),
-            },
-            "miner_3": {
-                "miner_1": get_distance(
-                    np.array([gmpy2.mpz(0.06e18)], dtype=object),
-                    np.array([gmpy2.mpz(0.05e18)], dtype=object),
-                    gmpy2.mpz(0.06e18),
-                ),
-                "miner_2": get_distance(
-                    np.array([gmpy2.mpz(0.06e18)], dtype=object),
-                    np.array([gmpy2.mpz(0.04e18)], dtype=object),
-                    gmpy2.mpz(0.06e18),
-                ),
-            },
-        }
-
-        result = get_apy_similarity_matrix(apys_and_allocations)
-
-        for miner_a in expected_similarity_matrix:
-            for miner_b in expected_similarity_matrix[miner_a]:
-                self.assertAlmostEqual(
-                    result[miner_a][miner_b],
-                    expected_similarity_matrix[miner_a][miner_b],
-                    places=5,
-                )
-
-    def test_get_allocation_similarity_matrix_empty(self) -> None:
-        apys_and_allocations = {
-            "miner_1": {
-                "apy": int(0.05e18),
-                "allocations": {"pool_1": 30, "pool_2": 20},
-            },
-            "miner_2": {
-                "apy": int(0.04e18),
-                "allocations": {"pool_1": 40, "pool_2": 10},
-            },
-            "miner_3": {"apy": 0, "allocations": None},
-        }
-        assets_and_pools = {
-            "pools": {
-                "pool_1": {"reserve_size": 100},
-                "pool_2": {"reserve_size": 100},
-            },
-            "total_assets": 100,
-        }
-
-        total_assets = assets_and_pools["total_assets"]
-
-        expected_similarity_matrix = {
-            "miner_1": {
-                "miner_2": get_distance(
-                    np.array([gmpy2.mpz(30), gmpy2.mpz(20)], dtype=object),
-                    np.array([gmpy2.mpz(40), gmpy2.mpz(10)], dtype=object),
-                    total_assets,
-                ),
-                "miner_3": float("inf"),
-            },
-            "miner_2": {
-                "miner_1": get_distance(
-                    np.array([gmpy2.mpz(40), gmpy2.mpz(10)], dtype=object),
-                    np.array([gmpy2.mpz(30), gmpy2.mpz(20)], dtype=object),
-                    total_assets,
-                ),
-                "miner_3": float("inf"),
-            },
-            "miner_3": {"miner_1": float("inf"), "miner_2": float("inf")},
-        }
-
-        result = get_allocation_similarity_matrix(apys_and_allocations, assets_and_pools)
-
-        for miner_a in expected_similarity_matrix:
-            for miner_b in expected_similarity_matrix[miner_a]:
-                self.assertAlmostEqual(
-                    result[miner_a][miner_b],
-                    expected_similarity_matrix[miner_a][miner_b],
-                    places=5,
-                )
-
-    def test_get_apy_similarity_matrix_empty(self) -> None:
-        apys_and_allocations = {
-            "miner_1": {
-                "apy": int(0.05e18),
-                "allocations": {"pool_1": 30, "pool_2": 20},
-            },
-            "miner_2": {
-                "apy": int(0.04e18),
-                "allocations": {"pool_1": 40, "pool_2": 10},
-            },
-            "miner_3": {"apy": 0, "allocations": None},
-        }
-
-        expected_similarity_matrix = {
-            "miner_1": {
-                "miner_2": get_distance(
-                    np.array([gmpy2.mpz(0.05e18)], dtype=object),
-                    np.array([gmpy2.mpz(0.04e18)], dtype=object),
-                    gmpy2.mpz(0.05e18),
-                ),
-                "miner_3": get_distance(
-                    np.array([gmpy2.mpz(0.05e18)], dtype=object), np.array([gmpy2.mpz(0)], dtype=object), gmpy2.mpz(0.05e18)
-                ),
-            },
-            "miner_2": {
-                "miner_1": get_distance(
-                    np.array([gmpy2.mpz(0.04e18)], dtype=object),
-                    np.array([gmpy2.mpz(0.05e18)], dtype=object),
-                    gmpy2.mpz(0.05e18),
-                ),
-                "miner_3": get_distance(
-                    np.array([gmpy2.mpz(0.04e18)], dtype=object), np.array([gmpy2.mpz(0)], dtype=object), gmpy2.mpz(0.04e18)
-                ),
-            },
-            "miner_3": {
-                "miner_1": get_distance(
-                    np.array([gmpy2.mpz(0)], dtype=object), np.array([gmpy2.mpz(0.05e18)], dtype=object), gmpy2.mpz(0.05e18)
-                ),
-                "miner_2": get_distance(
-                    np.array([gmpy2.mpz(0)], dtype=object), np.array([gmpy2.mpz(0.04e18)], dtype=object), gmpy2.mpz(0.04e18)
-                ),
-            },
-        }
-
-        result = get_apy_similarity_matrix(apys_and_allocations)
-
-        for miner_a in expected_similarity_matrix:
-            for miner_b in expected_similarity_matrix[miner_a]:
-                self.assertAlmostEqual(
-                    result[miner_a][miner_b],
-                    expected_similarity_matrix[miner_a][miner_b],
-                    places=5,
-                )
-
-    def test_calculate_penalties(self) -> None:
-        allocation_similarity_matrix = {
-            "1": {"2": 0.05, "3": 0.2},
-            "2": {"1": 0.05, "3": 0.1},
-            "3": {"1": 0.2, "2": 0.1},
-        }
-        apy_similarity_matrix = {
-            "1": {"2": 0.05, "3": 0.2},
-            "2": {"1": 0.05, "3": 0.1},
-            "3": {"1": 0.2, "2": 0.1},
-        }
-        axon_times = {"1": 1.0, "2": 2.0, "3": 3.0}
-
-        allocation_similarity_threshold = 0.2
-        apy_similarity_threshold = 0.1
-
-        expected_penalties = {"1": 0, "2": 1, "3": 1}
-        result = calculate_penalties(
-            allocation_similarity_matrix,
-            apy_similarity_matrix,
-            axon_times,
-            allocation_similarity_threshold,
-            apy_similarity_threshold,
-        )
-
-        self.assertEqual(result, expected_penalties)
-
-    def test_calculate_penalties_no_apy_similarities(self) -> None:
-        allocation_similarity_matrix = {
-            "1": {"2": 0.05, "3": 0.2},
-            "2": {"1": 0.05, "3": 0.1},
-            "3": {"1": 0.2, "2": 0.1},
-        }
-        apy_similarity_matrix = {
-            "1": {"2": 0.05, "3": 0.2},
-            "2": {"1": 0.05, "3": 0.1},
-            "3": {"1": 0.2, "2": 0.1},
-        }
-        axon_times = {"1": 1.0, "2": 2.0, "3": 3.0}
-        allocation_similarity_threshold = 0.2
-        apy_similarity_threshold = 0.05
-
-        expected_penalties = {"1": 0, "2": 1, "3": 0}
-        result = calculate_penalties(
-            allocation_similarity_matrix,
-            apy_similarity_matrix,
-            axon_times,
-            allocation_similarity_threshold,
-            apy_similarity_threshold,
-        )
-
-        self.assertEqual(result, expected_penalties)
-
-    def test_calculate_penalties_no_similarities(self) -> None:
-        allocation_similarity_matrix = {
-            "1": {"2": 0.5, "3": 0.6},
-            "2": {"1": 0.5, "3": 0.7},
-            "3": {"1": 0.6, "2": 0.7},
-        }
-        apy_similarity_matrix = {
-            "1": {"2": 0.5, "3": 0.6},
-            "2": {"1": 0.5, "3": 0.7},
-            "3": {"1": 0.6, "2": 0.7},
-        }
-        axon_times = {"1": 1.0, "2": 2.0, "3": 3.0}
-
-        allocation_similarity_threshold = 0.3
-        apy_similarity_threshold = 0.1
-
-        expected_penalties = {"1": 0, "2": 0, "3": 0}
-        result = calculate_penalties(
-            allocation_similarity_matrix,
-            apy_similarity_matrix,
-            axon_times,
-            allocation_similarity_threshold,
-            apy_similarity_threshold,
-        )
-
-        self.assertEqual(result, expected_penalties)
-
-    def test_calculate_penalties_equal_times(self) -> None:
-        allocation_similarity_matrix = {
-            "1": {"2": 0.05, "3": 0.05},
-            "2": {"1": 0.05, "3": 0.05},
-            "3": {"1": 0.05, "2": 0.05},
-        }
-        apy_similarity_matrix = {
-            "1": {"2": 0.05, "3": 0.05},
-            "2": {"1": 0.05, "3": 0.05},
-            "3": {"1": 0.05, "2": 0.05},
-        }
-
-        axon_times = {"1": 1.0, "2": 1.0, "3": 1.0}
-
-        allocation_similarity_threshold = 0.1
-
-        apy_similarity_threshold = 0.2
-
-        expected_penalties = {"1": 2, "2": 2, "3": 2}
-
-        result = calculate_penalties(
-            allocation_similarity_matrix,
-            apy_similarity_matrix,
-            axon_times,
-            allocation_similarity_threshold,
-            apy_similarity_threshold,
-        )
-
-        self.assertEqual(result, expected_penalties)
-
-    def test_calculate_rewards_with_adjusted_penalties(self) -> None:
-        miners = ["1", "2", "3"]
-        rewards_apy = np.array([1.0, 1.0, 1.0])
-        penalties = {"1": 0, "2": 1, "3": 2}
-
-        expected_rewards = np.array([1.0, 0.5, 0.0])
-        result = calculate_rewards_with_adjusted_penalties(miners, rewards_apy, penalties)
-
-        np.testing.assert_allclose(result, expected_rewards, rtol=0, atol=1e-5)
-
-    def test_calculate_rewards_with_no_penalties(self) -> None:
-        miners = ["1", "2", "3"]
-        rewards_apy = np.array([0.05, 0.04, 0.03])
-        penalties = {"1": 0, "2": 0, "3": 0}
-
-        expected_rewards = np.array([0.05, 0.04, 0.03])
-        result = calculate_rewards_with_adjusted_penalties(miners, rewards_apy, penalties)
-
-        np.testing.assert_allclose(result, expected_rewards, rtol=0, atol=1e-5)
-
-    def test_adjust_rewards_for_plagiarism(self) -> None:
-        rewards_apy = np.array([0.05 / 0.05, 0.04 / 0.05, 0.03 / 0.05])
-        apys_and_allocations = {
-            "0": {"apy": 50, "allocations": {"asset_1": 200, "asset_2": 300}},  # APY: int
-            "1": {"apy": 40, "allocations": {"asset_1": 202, "asset_2": 303}},
-            "2": {"apy": 30, "allocations": {"asset_1": 200, "asset_2": 400}},
-        }
-        assets_and_pools = {
-            "total_assets": 500,
-            "pools": {"asset_1": 1000, "asset_2": 1000},
-        }
-        uids = ["0", "1", "2"]
-        axon_times = {"0": 1.0, "1": 2.0, "2": 3.0}
-
-        allocation_similarity_threshold = 0.1
-
-        apy_similarity_threshold = 0.2
-
-        expected_rewards = np.array([1.0, 0.0, 0.03 / 0.05])
-
-        result = adjust_rewards_for_plagiarism(
-            self.vali,
-            rewards_apy,
-            apys_and_allocations,
-            assets_and_pools,
-            uids,
-            axon_times,
-            allocation_similarity_threshold,
-            apy_similarity_threshold,
-        )
-
-        np.testing.assert_array_almost_equal(result, expected_rewards, decimal=5)
-
-    def test_adjust_rewards_for_one_plagiarism(self) -> None:
-        rewards_apy = np.array([1.0, 1.0])
-        apys_and_allocations = {
-            "0": {"apy": 50, "allocations": {"asset_1": 200, "asset_2": 300}},
-            "1": {"apy": 50, "allocations": {"asset_1": 200, "asset_2": 300}},
-        }
-        assets_and_pools = {
-            "total_assets": 500,
-            "pools": {"asset_1": 1000, "asset_2": 1000},
-        }
-        uids = ["0", "1"]
-        axon_times = {"0": 1.0, "1": 2.0}
-
-        expected_rewards = np.array([1.0, 0.0])
-
-        allocation_similarity_threshold = 0.1
-        apy_similarity_threshold = 0.2
-
-        result = adjust_rewards_for_plagiarism(
-            self.vali,
-            rewards_apy,
-            apys_and_allocations,
-            assets_and_pools,
-            uids,
-            axon_times,
-            allocation_similarity_threshold,
-            apy_similarity_threshold,
-        )
-
-        np.testing.assert_array_almost_equal(result, expected_rewards, decimal=5)
-
 
 class TestCalculateApy(unittest.TestCase):
     @classmethod
@@ -1132,33 +524,33 @@ class TestCalculateApy(unittest.TestCase):
 class TestApyBinning(unittest.TestCase):
     def test_create_apy_bins_default_threshold(self) -> None:
         apys = {
-            "miner1": int(1.05e18),  # 105%
-            "miner2": int(1.04e18),  # 104%
-            "miner3": int(0.95e18),  # 95%
-            "miner4": int(0.94e18),  # 94%
+            "0": int(1.05e18),  # 105%
+            "1": int(1.04e18),  # 104%
+            "2": int(0.95e18),  # 95%
+            "3": int(0.94e18),  # 94%
         }
 
         bins = create_apy_bins(apys)  # Uses default threshold of 5%
 
         # With 5% threshold:
-        # Bin 0 should have miner1 and miner2 (105% and 104%)
-        # Bin 1 should have miner3 and miner4 (95% and 94%)
+        # Bin 0 should have UIDs 0 and 1 (105% and 104%)
+        # Bin 1 should have UIDs 2 and 3 (95% and 94%)
         self.assertEqual(len(bins), 2)
         self.assertEqual(len(bins[0]), 2)  # First bin should have 2 miners
         self.assertEqual(len(bins[1]), 2)  # Second bin should have 2 miners
 
         # Check specific miners are in correct bins
-        self.assertIn("miner1", bins[0])
-        self.assertIn("miner2", bins[0])
-        self.assertIn("miner3", bins[1])
-        self.assertIn("miner4", bins[1])
+        self.assertIn("0", bins[0])
+        self.assertIn("1", bins[0])
+        self.assertIn("2", bins[1])
+        self.assertIn("3", bins[1])
 
     def test_create_apy_bins_custom_threshold(self) -> None:
         apys = {
-            "miner1": int(1.05e18),  # 105%
-            "miner2": int(1.04e18),  # 104%
-            "miner3": int(0.95e18),  # 95%
-            "miner4": int(0.94e18),  # 94%
+            "0": int(1.05e18),  # 105%
+            "1": int(1.04e18),  # 104%
+            "2": int(0.95e18),  # 95%
+            "3": int(0.94e18),  # 94%
         }
 
         # Using a larger threshold of 20%
@@ -1167,7 +559,7 @@ class TestApyBinning(unittest.TestCase):
         # With 20% threshold, all miners should be in one bin
         self.assertEqual(len(bins), 1)
         self.assertEqual(len(bins[0]), 4)
-        self.assertListEqual(sorted(bins[0]), sorted(["miner1", "miner2", "miner3", "miner4"]))
+        self.assertListEqual(sorted(bins[0]), ["0", "1", "2", "3"])
 
     def test_create_apy_bins_empty(self) -> None:
         apys = {}
@@ -1175,58 +567,250 @@ class TestApyBinning(unittest.TestCase):
         self.assertEqual(len(bins), 0)
 
     def test_create_apy_bins_single_miner(self) -> None:
-        apys = {"miner1": int(1.05e18)}
+        apys = {"0": int(1.05e18)}
         bins = create_apy_bins(apys)
         self.assertEqual(len(bins), 1)
         self.assertEqual(len(bins[0]), 1)
-        self.assertEqual(bins[0][0], "miner1")
+        self.assertEqual(bins[0][0], "0")
 
 
 class TestBinRewards(unittest.TestCase):
-    def test_calculate_bin_rewards(self) -> None:
+    def setUp(self) -> None:
+        # Setup common test data
+        self.assets_and_pools = {
+            "total_assets": int(100e18),
+            "pools": {"pool1": {"some": "metadata"}, "pool2": {"some": "metadata"}},
+        }
+
+    def test_calculate_bin_rewards_with_timing(self) -> None:
         bins = {
-            0: ["miner1", "miner2"],  # higher APY bin
-            1: ["miner3", "miner4"],  # lower APY bin
+            0: ["0", "1"],  # higher APY bin
+            1: ["2", "3"],  # lower APY bin
         }
         allocations = {
-            "miner1": {"allocations": {"pool1": int(100e18), "pool2": 0}},
-            "miner2": {"allocations": {"pool1": 0, "pool2": int(100e18)}},
-            "miner3": {"allocations": {"pool1": int(50e18), "pool2": int(50e18)}},
-            "miner4": {"allocations": {"pool1": int(50e18), "pool2": int(50e18)}},
+            "0": {"allocations": {"pool1": int(100e18), "pool2": 0}},
+            "1": {"allocations": {"pool1": int(100e18), "pool2": 0}},  # Similar to UID 0 but later
+            "2": {"allocations": {"pool1": int(50e18), "pool2": int(50e18)}},
+            "3": {"allocations": {"pool1": int(50e18), "pool2": int(50e18)}},  # Similar to UID 2 but later
         }
-        total_assets = int(100e18)
+        axon_times = {
+            "0": 1.0,  # First response
+            "1": 2.0,  # Second response (similar to UID 0)
+            "2": 1.5,  # First response in lower bin
+            "3": 2.5,  # Second response (similar to UID 2)
+        }
 
-        rewards = calculate_bin_rewards(bins, allocations, total_assets)
+        rewards, penalties = calculate_bin_rewards(bins, allocations, self.assets_and_pools, axon_times)
 
-        # Check that rewards are normalized between 0 and 1
-        self.assertLessEqual(max(rewards.values()), 1.0)
-        self.assertGreaterEqual(min(rewards.values()), 0.0)
+        # Check that rewards and penalties are numpy arrays
+        self.assertIsInstance(rewards, np.ndarray)
+        self.assertIsInstance(penalties, np.ndarray)
 
-        # Check that miners in higher APY bin get better base rewards
-        avg_reward_bin0 = sum(rewards[m] for m in bins[0]) / len(bins[0])
-        avg_reward_bin1 = sum(rewards[m] for m in bins[1]) / len(bins[1])
-        self.assertGreater(avg_reward_bin0, avg_reward_bin1)
+        # Check array lengths
+        self.assertEqual(len(rewards), 4)
+        self.assertEqual(len(penalties), 4)
 
-        # Check that dissimilar allocations within same bin get better rewards
-        # miner1 and miner2 have different allocations
-        self.assertGreater(rewards["miner1"], rewards["miner3"])
-        self.assertGreater(rewards["miner2"], rewards["miner4"])
+        # Check that earlier responses get better rewards when allocations are similar
+        self.assertGreater(rewards[0], rewards[1])  # UID 0 should have better reward than UID 1
+        self.assertGreater(rewards[2], rewards[3])  # UID 2 should have better reward than UID 3
 
-        # Check that top performer bonus is applied
-        top_performer = max(rewards.items(), key=lambda x: x[1])[0]
-        self.assertGreaterEqual(rewards[top_performer], max(rewards[m] for m in rewards if m != top_performer))
+        # Check that first responses aren't penalized
+        self.assertEqual(penalties[0], 0)  # First response shouldn't be penalized
+        self.assertGreater(penalties[1], 0)  # Similar to UID 0 but later
+        self.assertEqual(penalties[2], 0)  # First response in its bin
+        self.assertGreater(penalties[3], 0)  # Similar to UID 2 but later
 
     def test_calculate_bin_rewards_single_miner(self) -> None:
-        bins = {0: ["miner1"]}
+        bins = {0: ["0"]}
         allocations = {
-            "miner1": {"allocations": {"pool1": int(100e18), "pool2": 0}},
+            "0": {"allocations": {"pool1": int(100e18), "pool2": 0}},
         }
+        axon_times = {"0": 1.0}
+
+        rewards, penalties = calculate_bin_rewards(bins, allocations, self.assets_and_pools, axon_times)
+
+        # Single miner should get maximum reward and no penalty
+        self.assertEqual(rewards[0], 1.0)
+        self.assertEqual(penalties[0], 0.0)
+
+    def test_top_performer_bonus(self) -> None:
+        bins = {
+            0: ["0", "1", "2"],
+        }
+        allocations = {
+            "0": {"allocations": {"pool1": int(100e18), "pool2": 0}},
+            "1": {"allocations": {"pool1": 0, "pool2": int(100e18)}},
+            "2": {"allocations": {"pool1": int(50e18), "pool2": int(50e18)}},
+        }
+        axon_times = {
+            "0": 1.0,
+            "1": 1.5,
+            "2": 2.0,
+        }
+
+        rewards, _ = calculate_bin_rewards(bins, allocations, self.assets_and_pools, axon_times)
+
+        # Verify top performer gets significantly better reward
+        top_performer_idx = np.argmax(rewards)
+        other_rewards = rewards[rewards != rewards[top_performer_idx]]
+        self.assertGreater(rewards[top_performer_idx], np.max(other_rewards) * 1.5)
+
+
+class TestBinRewardHelpers(unittest.TestCase):
+    def setUp(self) -> None:
+        # Setup common test data
+        self.assets_and_pools = {
+            "total_assets": int(100e18),
+            "pools": {"pool1": {"some": "metadata"}, "pool2": {"some": "metadata"}},
+        }
+
+    def test_calculate_allocation_distance(self) -> None:
+        alloc_a = np.array([gmpy2.mpz(int(100e18)), gmpy2.mpz(0)], dtype=object)
+        alloc_b = np.array([gmpy2.mpz(int(100e18)), gmpy2.mpz(0)], dtype=object)
         total_assets = int(100e18)
 
-        rewards = calculate_bin_rewards(bins, allocations, total_assets)
+        # Test identical allocations
+        distance = calculate_allocation_distance(alloc_a, alloc_b, total_assets)
+        self.assertEqual(distance, 0.0)
 
-        # Single miner should get maximum reward
-        self.assertEqual(rewards["miner1"], 1.0)
+        # Test completely different allocations
+        alloc_c = np.array([gmpy2.mpz(0), gmpy2.mpz(int(100e18))], dtype=object)
+        distance = calculate_allocation_distance(alloc_a, alloc_c, total_assets)
+        self.assertAlmostEqual(distance, 1.0, places=6)
+
+        # Test partial difference
+        alloc_d = np.array([gmpy2.mpz(int(50e18)), gmpy2.mpz(int(50e18))], dtype=object)
+        distance = calculate_allocation_distance(alloc_a, alloc_d, total_assets)
+        self.assertAlmostEqual(distance, 0.5, places=6)
+
+    def test_calculate_base_rewards(self) -> None:
+        bins = {
+            0: ["0", "1"],  # highest APY bin
+            1: ["2"],  # middle APY bin
+            2: ["3"],  # lowest APY bin
+        }
+        miner_uids = ["0", "1", "2", "3"]
+
+        rewards = calculate_base_rewards(bins, miner_uids)
+
+        # Check array type and length
+        self.assertIsInstance(rewards, np.ndarray)
+        self.assertEqual(len(rewards), 4)
+
+        # Check reward values
+        self.assertEqual(rewards[0], 1.0)  # First bin gets full reward
+        self.assertEqual(rewards[1], 1.0)  # First bin gets full reward
+        self.assertEqual(rewards[2], 0.9)  # Second bin gets 0.9
+        self.assertEqual(rewards[3], 0.8)  # Third bin gets 0.8
+
+    def test_apply_similarity_penalties(self) -> None:
+        bins = {0: ["0", "1", "2"]}
+        allocations = {
+            "0": {"allocations": {"pool1": int(100e18), "pool2": 0}},
+            "1": {"allocations": {"pool1": int(100e18), "pool2": 0}},  # Similar to 0
+            "2": {"allocations": {"pool1": 0, "pool2": int(100e18)}},  # Different
+        }
+        axon_times = {
+            "0": 1.0,  # First response
+            "1": 2.0,  # Second response
+            "2": 3.0,  # Third response
+        }
+        miner_uids = ["0", "1", "2"]
+
+        # Test with default threshold
+        penalties = apply_similarity_penalties(
+            bins, allocations, axon_times, self.assets_and_pools, miner_uids, similarity_threshold=1e-4
+        )
+
+        # Check array type and length
+        self.assertIsInstance(penalties, np.ndarray)
+        self.assertEqual(len(penalties), 3)
+
+        # First response should have no penalty
+        self.assertEqual(penalties[0], 0.0)
+        # Second response similar to first should be penalized
+        self.assertGreater(penalties[1], 0.0)
+        # Third response different from others should not be penalized
+        self.assertEqual(penalties[2], 0.0)
+
+    def test_apply_similarity_penalties_with_missing_pools(self) -> None:
+        bins = {0: ["0", "1"]}
+        # Missing pool2 in allocations
+        allocations = {
+            "0": {"allocations": {"pool1": int(100e18)}},
+            "1": {"allocations": {"pool1": int(100e18)}},
+        }
+        axon_times = {
+            "0": 1.0,
+            "1": 2.0,
+        }
+        miner_uids = ["0", "1"]
+
+        penalties = apply_similarity_penalties(bins, allocations, axon_times, self.assets_and_pools, miner_uids)
+
+        # Should still work with missing pools (treated as 0)
+        self.assertEqual(len(penalties), 2)
+        self.assertEqual(penalties[0], 0.0)
+        self.assertGreater(penalties[1], 0.0)
+
+    def test_apply_similarity_penalties_with_none_allocations(self) -> None:
+        bins = {0: ["0", "1", "2"]}
+        allocations = {
+            "0": {"allocations": {"pool1": int(100e18), "pool2": 0}},
+            "1": None,  # Missing allocation
+            "2": {"allocations": {"pool1": int(100e18), "pool2": 0}},
+        }
+        axon_times = {
+            "0": 1.0,
+            "1": 2.0,
+            "2": 3.0,
+        }
+        miner_uids = ["0", "1", "2"]
+
+        penalties = apply_similarity_penalties(bins, allocations, axon_times, self.assets_and_pools, miner_uids)
+
+        self.assertEqual(len(penalties), 3)
+        self.assertEqual(penalties[0], 0.0)  # First response
+        self.assertEqual(penalties[1], 0.0)  # None allocation should have no penalty
+        self.assertGreater(penalties[2], 0.0)  # Similar to first response
+
+    def test_format_allocations(self) -> None:
+        # Test with missing pools
+        allocations = {"pool1": int(100e18)}
+        formatted = format_allocations(allocations, self.assets_and_pools)
+
+        # Should have all pools
+        self.assertIn("pool1", formatted)
+        self.assertIn("pool2", formatted)
+        # Missing pool should be 0
+        self.assertEqual(formatted["pool2"], 0)
+
+        # Test with None allocations
+        formatted = format_allocations(None, self.assets_and_pools)
+        self.assertEqual(formatted["pool1"], 0)
+        self.assertEqual(formatted["pool2"], 0)
+
+        # Test with empty allocations
+        formatted = format_allocations({}, self.assets_and_pools)
+        self.assertEqual(formatted["pool1"], 0)
+        self.assertEqual(formatted["pool2"], 0)
+
+    def test_apply_top_performer_bonus(self) -> None:
+        rewards = np.array([0.5, 0.8, 0.3, 1.0])
+
+        boosted_rewards = apply_top_performer_bonus(rewards)
+
+        # Check array type and length
+        self.assertIsInstance(boosted_rewards, np.ndarray)
+        self.assertEqual(len(boosted_rewards), 4)
+
+        # Check that only top performer got bonus
+        self.assertEqual(boosted_rewards[3], rewards[3] * TOP_PERFORMERS_BONUS)
+        self.assertEqual(boosted_rewards[0], rewards[0])
+        self.assertEqual(boosted_rewards[2], rewards[2])
+
+        # Original array should not be modified
+        self.assertFalse(np.array_equal(rewards, boosted_rewards))
 
 
 if __name__ == "__main__":

--- a/tests/unit/validator/test_reward_helpers.py
+++ b/tests/unit/validator/test_reward_helpers.py
@@ -820,8 +820,10 @@ class TestNormalizationFunctions(unittest.TestCase):
         # Test basic normalization
         rewards = np.array([1.0, 2.0, 3.0, 4.0])
         normalized = normalize_rewards(rewards)
-        self.assertAlmostEqual(normalized[0], 0.0)  # Min should be 0
-        self.assertAlmostEqual(normalized[-1], 1.0)  # Max should be 1
+        self.assertAlmostEqual(min(normalized), 0.0)  # Min should be 0
+        self.assertAlmostEqual(normalized[0], min(normalized))
+        self.assertAlmostEqual(max(normalized), 1.0)  # Max should be 1
+        self.assertAlmostEqual(normalized[-1], max(normalized))
 
         # Test custom range
         normalized = normalize_rewards(rewards, min_val=0.5, max_val=0.8)


### PR DESCRIPTION
This update introduces a change to the incentive mechanism.

Here's a brief breakdown of the changes that will be introduced

1. Firstly, when before scoring, miners will be grouped into bins based on their APY (the ranges for each these bins may be determined automatically)
2. Then, score the miners based on their APY
3. and then penalize miners who have similar allocations to other miners *within each APY group*.

This would effectively remove the need for the current APY similarity checking mechanism. 

To add to the steps above, another step (either after 2 or 3) which involves performing some sort of operation that would make it so that the top few miners (or even, just the top miner) receive an outsized reward vs. the rest of the miners in the subnet. I think this makes sense as the outputs of the top miner(s) are the most useful anyway, and it also eliminates UID pressure.

![image](https://github.com/user-attachments/assets/45ad53e3-e8fa-4d2a-aabd-a23b4bce7895)

