### PR TITLE
Add dynamic bin threshold

### DIFF
--- a/min_compute.yml
+++ b/min_compute.yml
@@ -10,7 +10,7 @@
 # Even then - storage isn't utilized very often - so disk performance won't really be a bottleneck vs, CPU, RAM, 
 # and network bandwidth.
 
-version: '2.2.9' # update this version key as needed, ideally should match your release version
+version: '2.2.10' # update this version key as needed, ideally should match your release version
 
 compute_spec:
 

--- a/sturdy/__init__.py
+++ b/sturdy/__init__.py
@@ -17,7 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the version of the template module.
-__version__ = "2.2.9"
+__version__ = "2.2.10"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 

--- a/sturdy/constants.py
+++ b/sturdy/constants.py
@@ -17,7 +17,6 @@ TOTAL_ALLOC_THRESHOLD = 0.98
 ALLOCATION_SIMILARITY_THRESHOLD = 1e-4  # similarity threshold for plagiarism checking
 
 # Constants for APY-based binning and rewards
-APY_BIN_THRESHOLD = 0.01  # 1% difference in APY to create new bin
 TOP_PERFORMERS_BONUS = 4.0  # Multiplier for top performing miners
 TOP_PERFORMERS_COUNT = 10  # Number of top performers to receive bonus
 

--- a/sturdy/constants.py
+++ b/sturdy/constants.py
@@ -17,6 +17,7 @@ TOTAL_ALLOC_THRESHOLD = 0.98
 ALLOCATION_SIMILARITY_THRESHOLD = 1e-4  # similarity threshold for plagiarism checking
 
 # Constants for APY-based binning and rewards
+APY_BIN_THRESHOLD_FALLBACK = 1e-5  # Fallback threshold: 0.00001 difference in APY to create new bin
 TOP_PERFORMERS_BONUS = 4.0  # Multiplier for top performing miners
 TOP_PERFORMERS_COUNT = 10  # Number of top performers to receive bonus
 

--- a/sturdy/validator/apy_binning.py
+++ b/sturdy/validator/apy_binning.py
@@ -39,6 +39,8 @@ def create_apy_bins(apys: dict[str, int]) -> dict[int, list[str]]:
         posinf=0.0,  # Replace +inf with 0
         neginf=0.0,  # Replace -inf with 0
     )
+    apy_values = np.abs(apy_values)
+
     # Clip very low APYs (bottom 10%) up to the 10th percentile to reduce noise
     # use 'higher' to use actual higher value from apys, no interpolation
     q10 = np.percentile(apy_values, 10, method="higher")

--- a/sturdy/validator/apy_binning.py
+++ b/sturdy/validator/apy_binning.py
@@ -293,8 +293,9 @@ def calculate_bin_rewards(
     # TODO: Apply exponential transformation? (disabled for now)
     # rewards = exponentiate_rewards(rewards)  # noqa: ERA001
 
-    # Apply bonus to top performers
-    rewards = apply_top_performer_bonus(rewards)
+    # TODO: Fix apply_top_performer_bonus before enabling
+    # Currently, it favors accounts that appear later in the rewards array
+    # rewards = apply_top_performer_bonus(rewards)
 
     # Normalize final rewards
     rewards = normalize_rewards(rewards)

--- a/sturdy/validator/apy_binning.py
+++ b/sturdy/validator/apy_binning.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from sturdy.constants import (
     ALLOCATION_SIMILARITY_THRESHOLD,
+    APY_BIN_THRESHOLD_FALLBACK,
     NORM_EXP_POW,
     TOP_PERFORMERS_BONUS,
     TOP_PERFORMERS_COUNT,
@@ -29,7 +30,7 @@ def calculate_cv_threshold(apys: list[int]) -> float:
     # Calculate coefficient of variation as a dynamic threshold
     std_dev = np.std(apy_values)
     mean = np.mean(apy_values)
-    return float(std_dev / mean) if mean != 0 and std_dev != 0 else 1e-5  # Fallback value
+    return float(std_dev / mean) if mean != 0 and std_dev != 0 else APY_BIN_THRESHOLD_FALLBACK
 
 
 def create_apy_bins(apys: dict[str, int], threshold_func=calculate_cv_threshold) -> dict[int, list[str]]:

--- a/sturdy/validator/apy_binning.py
+++ b/sturdy/validator/apy_binning.py
@@ -20,7 +20,6 @@ def calculate_cv_threshold(apys: list[int]) -> float:
         posinf=0.0,  # Replace +inf with 0
         neginf=0.0,  # Replace -inf with 0
     )
-    apy_values = np.abs(apy_values)
 
     # Clip very low APYs (bottom 10%) up to the 10th percentile to reduce noise
     # use 'higher' to use actual higher value from apys, no interpolation

--- a/tests/unit/validator/test_reward_helpers.py
+++ b/tests/unit/validator/test_reward_helpers.py
@@ -546,7 +546,7 @@ class TestApyBinning(unittest.TestCase):
         }
         bins = create_apy_bins(apys)
 
-        self.assertEqual(len(bins), 3)
+        self.assertEqual(len(bins), 4)
         self.assertEqual(len(bins[0]), 13)  # First bin has 13 miners
         self.assertEqual(len(bins[1]), 1)  # Second  bin has 1 miners
         self.assertEqual(len(bins[2]), 1)  # Third bin has 2 miners

--- a/tests/unit/validator/test_reward_helpers.py
+++ b/tests/unit/validator/test_reward_helpers.py
@@ -524,44 +524,89 @@ class TestCalculateApy(unittest.TestCase):
 
 
 class TestApyBinning(unittest.TestCase):
-    def test_create_apy_bins_default_threshold(self) -> None:
+    # Actual apys from sturdy_tbtc_aggregator
+    def test_real_world_apys_case1(self) -> None:
+        apys = {
+            "0": 2430768276972491,
+            "1": 2430768276942237,
+            "2": 2430768276939231,
+            "3": 2430768276829685,
+            "4": 2430768276827723,
+            "5": 2430768276823904,
+            "6": 2430768276810737,
+            "7": 2430768276765696,
+            "8": 2430768276762190,
+            "9": 2430768276705227,
+            "10": 2430768276705227,
+            "11": 2430768276668354,
+            "12": 2430768276569505,
+            "13": 2430767490721887,
+            "14": 2430766893869556,
+            "15": 2430766561865656,
+        }
+        bins = create_apy_bins(apys)
+
+        self.assertEqual(len(bins), 3)
+        self.assertEqual(len(bins[0]), 13)  # First bin has 13 miners
+        self.assertEqual(len(bins[1]), 1)  # Second  bin has 1 miners
+        self.assertEqual(len(bins[2]), 1)  # Third bin has 2 miners
+        self.assertEqual(len(bins[3]), 1)  # Fourth bin has 3 miners
+
+        # Check specific miners are in correct bins
+        for uid in range(13):
+            self.assertIn(str(uid), bins[0])
+
+    # Similar to test_real_world_apys_case1 just with low apy miners removed
+    # This shows a case when all miners improve their alogs
+    def test_real_world_apys_case2(self) -> None:
+        apys = {
+            "0": 2430768276972491,
+            "1": 2430768276942237,
+            "2": 2430768276939231,
+            "3": 2430768276829685,
+            "4": 2430768276827723,
+            "5": 2430768276823904,
+            "6": 2430768276810737,
+            "7": 2430768276765696,
+            "8": 2430768276762190,
+            "9": 2430768276705227,
+            "10": 2430768276705227,
+            "11": 2430768276668354,
+            "12": 2430768276569505,
+        }
+        bins = create_apy_bins(apys)
+
+        self.assertEqual(len(bins), 4)
+        self.assertEqual(len(bins[0]), 3)  # First bin has 3 miners
+        self.assertEqual(len(bins[1]), 6)  # Second  bin has 6 miners
+        self.assertEqual(len(bins[2]), 3)  # Third bin has 2 miners
+        self.assertEqual(len(bins[3]), 1)  # Fourth bin has 3 miners
+
+    def test_create_apy_bins(self) -> None:
         apys = {
             "0": int(1.05e18),  # 105%
             "1": int(1.04e18),  # 104%
             "2": int(0.95e18),  # 95%
             "3": int(0.94e18),  # 94%
+            "4": 1,  # noisy apy
         }
 
-        bins = create_apy_bins(apys)  # Uses default threshold of 5%
+        bins = create_apy_bins(apys)
 
-        # With 5% threshold:
         # Bin 0 should have UIDs 0 and 1 (105% and 104%)
         # Bin 1 should have UIDs 2 and 3 (95% and 94%)
-        self.assertEqual(len(bins), 2)
+        # Bin 2 has the noisy value
+        self.assertEqual(len(bins), 3)
         self.assertEqual(len(bins[0]), 2)  # First bin should have 2 miners
         self.assertEqual(len(bins[1]), 2)  # Second bin should have 2 miners
+        self.assertEqual(len(bins[2]), 1)  # Third bin should have 1 miner
 
         # Check specific miners are in correct bins
         self.assertIn("0", bins[0])
         self.assertIn("1", bins[0])
         self.assertIn("2", bins[1])
         self.assertIn("3", bins[1])
-
-    def test_create_apy_bins_custom_threshold(self) -> None:
-        apys = {
-            "0": int(1.05e18),  # 105%
-            "1": int(1.04e18),  # 104%
-            "2": int(0.95e18),  # 95%
-            "3": int(0.94e18),  # 94%
-        }
-
-        # Using a larger threshold of 20%
-        bins = create_apy_bins(apys, bin_threshold=0.20)
-
-        # With 20% threshold, all miners should be in one bin
-        self.assertEqual(len(bins), 1)
-        self.assertEqual(len(bins[0]), 4)
-        self.assertListEqual(sorted(bins[0]), ["0", "1", "2", "3"])
+        self.assertIn("4", bins[2])
 
     def test_create_apy_bins_empty(self) -> None:
         apys = {}


### PR DESCRIPTION
This pull request adds support for a dynamic bin threshold, calculated using the coefficient of variation (CV).

The coefficient of variation measures how spread out the APY values are relative to their mean. It’s a scale-independent metric, which makes it well-suited for adapting bin thresholds across different APY distributions — whether values are large or small.

This solution would also work well with alpha token pools on Bittensor.