### PR TITLE
Release/2.2.11

### DIFF
--- a/min_compute.yml
+++ b/min_compute.yml
@@ -10,7 +10,7 @@
 # Even then - storage isn't utilized very often - so disk performance won't really be a bottleneck vs, CPU, RAM, 
 # and network bandwidth.
 
-version: '2.2.10' # update this version key as needed, ideally should match your release version
+version: '2.2.11' # update this version key as needed, ideally should match your release version
 
 compute_spec:
 

--- a/sturdy/__init__.py
+++ b/sturdy/__init__.py
@@ -17,7 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the version of the template module.
-__version__ = "2.2.10"
+__version__ = "2.2.11"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 

--- a/sturdy/validator/apy_binning.py
+++ b/sturdy/validator/apy_binning.py
@@ -22,10 +22,10 @@ def calculate_cv_threshold(apys: list[int]) -> float:
         neginf=0.0,  # Replace -inf with 0
     )
 
-    # Clip very low APYs (bottom 10%) up to the 10th percentile to reduce noise
-    # use 'higher' to use actual higher value from apys, no interpolation
-    q10 = np.percentile(apy_values, 10, method="higher")
-    apy_values = np.where(apy_values < q10, q10, apy_values)
+    # Remove lower than 90% quantile from threshold estimation to reduce the noise
+    apy_values = apy_values[apy_values > np.percentile(apy_values, 90)]
+    if apy_values.size == 0:
+        return APY_BIN_THRESHOLD_FALLBACK
 
     # Calculate coefficient of variation as a dynamic threshold
     std_dev = np.std(apy_values)

--- a/tests/unit/validator/test_reward_helpers.py
+++ b/tests/unit/validator/test_reward_helpers.py
@@ -546,41 +546,23 @@ class TestApyBinning(unittest.TestCase):
         }
         bins = create_apy_bins(apys)
 
-        self.assertEqual(len(bins), 4)
-        self.assertEqual(len(bins[0]), 13)  # First bin has 13 miners
-        self.assertEqual(len(bins[1]), 1)  # Second  bin has 1 miners
-        self.assertEqual(len(bins[2]), 1)  # Third bin has 2 miners
-        self.assertEqual(len(bins[3]), 1)  # Fourth bin has 3 miners
+        self.assertEqual(len(bins), 11)
+        self.assertEqual(len(bins[0]), 1)
+        self.assertEqual(len(bins[1]), 2)
+        self.assertEqual(len(bins[2]), 3)
+        self.assertEqual(len(bins[3]), 1)
+        self.assertEqual(len(bins[4]), 2)
+        self.assertEqual(len(bins[5]), 2)
+        self.assertEqual(len(bins[6]), 1)
+        self.assertEqual(len(bins[7]), 1)
+        self.assertEqual(len(bins[8]), 1)
+        self.assertEqual(len(bins[9]), 1)
+        self.assertEqual(len(bins[10]), 1)
 
         # Check specific miners are in correct bins
-        for uid in range(13):
-            self.assertIn(str(uid), bins[0])
-
-    # Similar to test_real_world_apys_case1 just with low apy miners removed
-    # This shows a case when all miners improve their alogs
-    def test_real_world_apys_case2(self) -> None:
-        apys = {
-            "0": 2430768276972491,
-            "1": 2430768276942237,
-            "2": 2430768276939231,
-            "3": 2430768276829685,
-            "4": 2430768276827723,
-            "5": 2430768276823904,
-            "6": 2430768276810737,
-            "7": 2430768276765696,
-            "8": 2430768276762190,
-            "9": 2430768276705227,
-            "10": 2430768276705227,
-            "11": 2430768276668354,
-            "12": 2430768276569505,
-        }
-        bins = create_apy_bins(apys)
-
-        self.assertEqual(len(bins), 4)
-        self.assertEqual(len(bins[0]), 3)  # First bin has 3 miners
-        self.assertEqual(len(bins[1]), 6)  # Second  bin has 6 miners
-        self.assertEqual(len(bins[2]), 3)  # Third bin has 2 miners
-        self.assertEqual(len(bins[3]), 1)  # Fourth bin has 3 miners
+        self.assertIn("0", bins[0])
+        self.assertIn("1", bins[1])
+        self.assertIn("2", bins[1])
 
     def test_create_apy_bins(self) -> None:
         apys = {
@@ -596,17 +578,19 @@ class TestApyBinning(unittest.TestCase):
         # Bin 0 should have UIDs 0 and 1 (105% and 104%)
         # Bin 1 should have UIDs 2 and 3 (95% and 94%)
         # Bin 2 has the noisy value
-        self.assertEqual(len(bins), 3)
-        self.assertEqual(len(bins[0]), 2)  # First bin should have 2 miners
-        self.assertEqual(len(bins[1]), 2)  # Second bin should have 2 miners
-        self.assertEqual(len(bins[2]), 1)  # Third bin should have 1 miner
+        self.assertEqual(len(bins), 5)
+        self.assertEqual(len(bins[0]), 1)
+        self.assertEqual(len(bins[1]), 1)
+        self.assertEqual(len(bins[2]), 1)
+        self.assertEqual(len(bins[3]), 1)
+        self.assertEqual(len(bins[4]), 1)
 
         # Check specific miners are in correct bins
         self.assertIn("0", bins[0])
-        self.assertIn("1", bins[0])
-        self.assertIn("2", bins[1])
-        self.assertIn("3", bins[1])
-        self.assertIn("4", bins[2])
+        self.assertIn("1", bins[1])
+        self.assertIn("2", bins[2])
+        self.assertIn("3", bins[3])
+        self.assertIn("4", bins[4])
 
     def test_create_apy_bins_empty(self) -> None:
         apys = {}


### PR DESCRIPTION
This PR improves the method used to estimate the bin threshold. The previous implementation was prone to too little bin fragmentation due to noise in the APY data — especially in the lower percentiles.

Changes:
	•	Adjusted the threshold estimation to only consider the top 10% (90th quantile and above) of APY values.
	•	This reduces the influence of noisy or low-value APYs, resulting in more accurate and dynamic bin splitting.

Why:

Filtering out lower APYs reduces variance and leads to a more stable and meaningful threshold, improving downstream allocation and performance.