### PR TITLE
Release 3.0.3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 ETHEREUM_MAINNET_PROVIDER_URL="https://eth-mainnet.g.alchemy.com/v2/<YOUR API KEY>"
 BITTENSOR_MAINNET_PROVIDER_URL="wss://archive.chain.opentensor.ai:443"
+WANDB_API_KEY=

--- a/min_compute.yml
+++ b/min_compute.yml
@@ -10,7 +10,7 @@
 # Even then - storage isn't utilized very often - so disk performance won't really be a bottleneck vs, CPU, RAM, 
 # and network bandwidth.
 
-version: '3.0.2' # update this version key as needed, ideally should match your release version
+version: '3.0.3' # update this version key as needed, ideally should match your release version
 
 compute_spec:
 

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -26,7 +26,6 @@ import bittensor as bt
 import uvicorn
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, Response
-from pydantic import BaseModel
 from starlette.status import (
     HTTP_400_BAD_REQUEST,
     HTTP_401_UNAUTHORIZED,
@@ -36,7 +35,7 @@ from web3.constants import ADDRESS_ZERO
 
 # import base validator class which takes care of most of the boilerplate
 from sturdy.base.validator import BaseValidatorNeuron
-from sturdy.constants import DB_DIR, MIN_TOTAL_ASSETS_AMOUNT, ORGANIC_SCORING_PERIOD
+from sturdy.constants import DB_DIR, MIN_TOTAL_ASSETS_AMOUNT
 
 # Bittensor Validator Template:
 from sturdy.pools import POOL_TYPES, PoolFactory
@@ -53,8 +52,8 @@ from sturdy.providers import POOL_DATA_PROVIDER_TYPE
 from sturdy.utils.misc import get_synapse_from_body
 
 # api key db
-from sturdy.validator import forward, query_and_score_miners, sql
-from sturdy.validator.forward import get_metadata, query_top_n_miners
+from sturdy.validator import forward, sql
+from sturdy.validator.forward import query_top_n_miners
 
 
 class Validator(BaseValidatorNeuron):

--- a/sturdy/__init__.py
+++ b/sturdy/__init__.py
@@ -17,7 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the version of the template module.
-__version__ = "3.0.2"
+__version__ = "3.0.3"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 

--- a/sturdy/constants.py
+++ b/sturdy/constants.py
@@ -4,9 +4,8 @@ QUERY_FREQUENCY = 600  # time in seconds between validator queries
 QUERY_TIMEOUT = 3  # timeout (seconds)
 MINER_SYNC_FREQUENCY = 300  # time in seconds between miner syncs
 
-ORGANIC_SCORING_PERIOD = 28800  # scoring period in seconds
-MIN_SCORING_PERIOD = 7200  # min. synthetic scoring period in seconds
-MAX_SCORING_PERIOD = 43200  # max. synthetic scoring period in seconds
+MIN_SCORING_PERIOD = 43200  # min. synthetic scoring period in seconds
+MAX_SCORING_PERIOD = 86400  # max. synthetic scoring period in seconds
 SCORING_PERIOD_STEP = 3600  # scoring period increments in seconds
 
 SCORING_WINDOW = 420  # scoring window


### PR DESCRIPTION
- Increased scoring period range from 12 to 24 hours.
- Dockerized validator, and also hooked it up to watchtower for auto-updating functionality (#100)