### PR TITLE
Release 3.0.4

### DIFF
--- a/docs/api_usage.md
+++ b/docs/api_usage.md
@@ -122,11 +122,26 @@ Here's an example of a request to obtain a suggestion on how to allocate TAO acr
 curl -X POST \
   http://{HOST_ADDRESS}/allocate_bt \
   -H 'Content-Type: application/json
-  -H 'Authorization : Bearer {API_KEY}' \
+  -H 'Authorization: Bearer {API_KEY}' \
   -d '{
     "netuids": [3, 10, 64],
     "total_assets": 100000000000,
     "num_allocs": 1
+}'
+```
+
+Optionally, you may also specify how much you may have already allocated across the pools. This is useful information to provide if you want the miners to account for slippage when rebalancing your allocations:
+
+```bash
+curl -X POST \
+  http://{HOST_ADDRESS}/allocate_bt \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer {API_KEY}' \
+  -d '{
+    "netuids": [3, 10, 64],
+    "total_assets": 100000000000,
+    "num_allocs": 1
+    "current_allocations": {"3": 25000000000}
 }'
 ```
 
@@ -135,6 +150,7 @@ Some annotations are provided below to further help understand the request forma
     "netuids": [3, 10, 64], # netuids of the subnets miners can return allocations for
     "total_assets": 100000000000, # total assets available to a miner to allocate (in RAO - 1e9 RAO = 1 TAO)
     "num_allocs": 1 # number of top allocations to return - by default this is set to 1
+    "current_allocations": {"3": 25000000000} # current allocations across the pools - this is used to determine how much to allocate to each pool
 }
 ```
 

--- a/min_compute.yml
+++ b/min_compute.yml
@@ -10,7 +10,7 @@
 # Even then - storage isn't utilized very often - so disk performance won't really be a bottleneck vs, CPU, RAM, 
 # and network bandwidth.
 
-version: '3.0.3' # update this version key as needed, ideally should match your release version
+version: '3.0.4' # update this version key as needed, ideally should match your release version
 
 compute_spec:
 

--- a/sturdy/__init__.py
+++ b/sturdy/__init__.py
@@ -17,7 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the version of the template module.
-__version__ = "3.0.3"
+__version__ = "3.0.4"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 

--- a/sturdy/algo.py
+++ b/sturdy/algo.py
@@ -24,7 +24,10 @@ async def naive_algorithm(self: BaseMinerNeuron, synapse: AllocateAssets) -> dic
     for uid, pool in pools.items():
         if isinstance(pool, BittensorAlphaTokenPool):
             pools[uid] = PoolFactory.create_pool(
-                pool_type=pool.pool_type, netuid=pool.netuid, pool_data_provider_type=pool.pool_data_provider_type
+                pool_type=pool.pool_type,
+                netuid=pool.netuid,
+                current_amount=pool.current_amount,
+                pool_data_provider_type=pool.pool_data_provider_type,
             )
         else:
             pools[uid] = PoolFactory.create_pool(

--- a/sturdy/protocol.py
+++ b/sturdy/protocol.py
@@ -99,6 +99,7 @@ class BTAlphaPoolRequest(BaseModel):
 
     netuids: list[int]
     total_assets: int
+    current_allocations: dict[int, int] = Field(default={}, description="current allocations across alpha token pools")
     num_allocs: int = Field(default=1, description="number of miner allocations to receive")
 
 

--- a/sturdy/utils/misc.py
+++ b/sturdy/utils/misc.py
@@ -87,6 +87,21 @@ def randrange_float(
     return format_num_prec(start + random_step * step, sig=sig, max_prec=max_prec)
 
 
+def generate_random_partition_np(
+    total_sum: int,
+    n: int,
+    rng_gen: np.random.RandomState = np.random.RandomState(),  # noqa: B008
+) -> np.ndarray:
+    if n <= 0 or total_sum < 0:
+        raise ValueError("N must be > 0 and total_sum must be >= 0")
+
+    # Generate N-1 sorted random integers between 0 and total_sum
+    break_points = np.sort(rng_gen.randint(0, total_sum, n - 1))
+
+    # Compute the differences between successive breakpoints
+    return np.diff(np.concatenate(([0], break_points, [total_sum])))
+
+
 async def async_retry_with_backoff(func, *args: Any, **kwargs: Any) -> Any:
     """
     Retry a function with exponential backoff and jitter when rate limited.

--- a/sturdy/validator/forward.py
+++ b/sturdy/validator/forward.py
@@ -70,7 +70,7 @@ async def forward(self) -> Any:
         try:
             challenge_data = await generate_challenge_data(chain_data_provider)
         except Exception as e:
-            bt.logging.error(f"Failed to generate challenge data: {e}")
+            bt.logging.exception(f"Failed to generate challenge data: {e}")
             continue
 
         request_uuid = str(uuid.uuid4()).replace("-", "")

--- a/sturdy/validator/reward.py
+++ b/sturdy/validator/reward.py
@@ -22,12 +22,13 @@ from typing import cast
 import bittensor as bt
 import numpy.typing as npt
 from async_lru import alru_cache
+from bittensor import Balance
 from web3 import Web3
 
 from sturdy.constants import QUERY_TIMEOUT
 from sturdy.pools import POOL_TYPES, ChainBasedPoolModel, PoolFactory, check_allocations
 from sturdy.protocol import AllocationsDict, AllocInfo
-from sturdy.utils.bt_alpha import get_vali_avg_apy
+from sturdy.utils.bt_alpha import fetch_dynamic_info, get_vali_avg_apy
 from sturdy.utils.ethmath import wei_div
 from sturdy.utils.misc import get_scoring_period_length
 from sturdy.validator.apy_binning import calculate_bin_rewards, create_apy_bins
@@ -163,16 +164,32 @@ async def annualized_yield_pct(
                         last_block = metadata["block"]
                         last_price = metadata["price_rao"]
 
+                        dynamic_info: bt.DynamicInfo = await fetch_dynamic_info(
+                            sub=pool_data_provider, block=last_block, netuid=pool.netuid
+                        )
+                        delta = initial_alloc - pool.current_amount
+
+                        # consider slippage
+                        alpha_lost = 0
+                        if delta > 0:
+                            _, alpha_lost_bal = dynamic_info.tao_to_alpha_with_slippage(Balance.from_rao(delta))
+                            alpha_lost = alpha_lost_bal.rao
+                        elif delta < 0:
+                            alpha_amount = int(abs(delta) / dynamic_info.price)
+                            _, alpha_lost = dynamic_info.alpha_to_tao_with_slippage(Balance.from_rao(alpha_amount))
+
                         curr_price = pool._price_rao
+                        delta_tao = Balance.from_rao(delta).tao
                         annualized_alpha_apy = await get_vali_avg_apy(
                             subtensor=pool_data_provider,
                             netuid=pool.netuid,
                             hotkey=vali_hotkey,
                             block=last_block,
                             end_block=current_block,
+                            delta_tao=delta_tao,
                         )
 
-                        alpha_amount = int(initial_alloc * (1 + annualized_alpha_apy))
+                        alpha_amount = int((initial_alloc - alpha_lost) * (1 + annualized_alpha_apy))
                         tao_pct_return = ((alpha_amount * curr_price) - (initial_alloc * last_price)) / (
                             alpha_amount * curr_price
                         )
@@ -288,6 +305,7 @@ async def get_rewards(self, active_allocation, chain_data_provider: Web3 | bt.As
             new_pool = PoolFactory.create_pool(
                 pool_type=pool["pool_type"],
                 netuid=int(pool["netuid"]),
+                current_amount=int(pool["current_amount"]),
                 pool_data_provider_type=pool["pool_data_provider_type"],
             )
         else:


### PR DESCRIPTION
- account for current allocations across bittensor alpha token pools
- consider slippage given current allocations
- updated `/allocate_bt` endpoint to account for the above
- updated api usage docs