### PR TITLE
Release/3.0.7

### DIFF
--- a/min_compute.yml
+++ b/min_compute.yml
@@ -10,7 +10,7 @@
 # Even then - storage isn't utilized very often - so disk performance won't really be a bottleneck vs, CPU, RAM, 
 # and network bandwidth.
 
-version: '3.0.6' # update this version key as needed, ideally should match your release version
+version: '3.0.7' # update this version key as needed, ideally should match your release version
 
 compute_spec:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ loguru==0.7.0
 wandb==0.18.7
 annotated-types==0.7.0
 anyio==4.6.2.post1
-bittensor==9.5.0
+bittensor==9.6.0
 bittensor-cli==9.4.1
 colorama==0.4.6
 decorator==5.1.1

--- a/sturdy/__init__.py
+++ b/sturdy/__init__.py
@@ -17,7 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the version of the template module.
-__version__ = "3.0.6"
+__version__ = "3.0.7"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 

--- a/sturdy/providers.py
+++ b/sturdy/providers.py
@@ -23,17 +23,7 @@ class PoolProviderFactory:
         if provider == POOL_DATA_PROVIDER_TYPE.ETHEREUM_MAINNET:
             return AsyncWeb3(AsyncWeb3.AsyncHTTPProvider(url, **kwargs))
         if provider == POOL_DATA_PROVIDER_TYPE.BITTENSOR_MAINNET:
-            # a dict of keyword arguments to pass to the constructor
-            config = {
-                "subtensor": {
-                    "chain_endpoint": url,
-                }
-            }
-            args_config = kwargs.get("config", {})
-            # Merge the default config with the provided config
-            config.update(args_config)
-            kwargs["config"] = bt.config.fromDict(config)
-            subtensor = bt.AsyncSubtensor(**kwargs)
+            subtensor = bt.AsyncSubtensor(url)
             await subtensor.initialize()
             return subtensor
         raise ValueError(f"Unsupported provider type: {provider}")

--- a/sturdy/validator/reward.py
+++ b/sturdy/validator/reward.py
@@ -176,7 +176,9 @@ async def annualized_yield_pct(
                             alpha_lost = alpha_lost_bal.rao
                         elif delta < 0:
                             alpha_num = int(abs(delta) / dynamic_info.price)
-                            _, tao_lost_bal = dynamic_info.alpha_to_tao_with_slippage(Balance.from_rao(alpha_num))
+                            _, tao_lost_bal = dynamic_info.alpha_to_tao_with_slippage(
+                                Balance.from_rao(alpha_num, netuid=pool.netuid)
+                            )
                             alpha_lost = int(tao_lost_bal.rao * (last_price / 1e9))
 
                         curr_price = pool._price_rao


### PR DESCRIPTION
- set netuid of alpha amount when calculating conversion rate from alpha to tao
- simpler Bittensor mainnet provider connection init.
- updated Bittensor sdk version to 9.6.0