### PR TITLE
Release 3.0.8

### DIFF
--- a/docs/validator.md
+++ b/docs/validator.md
@@ -205,8 +205,10 @@ docker compose down
 
 The docker compose configuration mounts these volumes:
 
-- `.:/app` - Mounts the current directory to allow database persistence
-- `~/.bittensor/wallets/:/root/.bittensor/wallets` - Mounts your local wallet directory
+- `${DB_DIR:-./validator_database.db}:/app/validator_database.db` - Mounts your local database file for persistence
+- `~/.bittensor/wallets/:/root/.bittensor/wallets` - Mounts wallet directory
+- `~/.bittensor/miners/:/root/.bittensor/miners/` - Mounts miners directory which stores saved weights
+- `.env/:/app/.env` - Mounts your environment configuration file
 
 ### Auto-Updates
 
@@ -220,8 +222,7 @@ Run with custom wallet and ports:
 ```bash
 WALLET_NAME=myvalidator \
 WALLET_HOTKEY=mykey \
-AXON_PORT=9001 \
-API_PORT=9000 \
+API_PORT=3000 \
 docker compose up -d
 ```
 

--- a/min_compute.yml
+++ b/min_compute.yml
@@ -10,7 +10,7 @@
 # Even then - storage isn't utilized very often - so disk performance won't really be a bottleneck vs, CPU, RAM, 
 # and network bandwidth.
 
-version: '3.0.7' # update this version key as needed, ideally should match your release version
+version: '3.0.8' # update this version key as needed, ideally should match your release version
 
 compute_spec:
 

--- a/sturdy/__init__.py
+++ b/sturdy/__init__.py
@@ -17,7 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the version of the template module.
-__version__ = "3.0.7"
+__version__ = "3.0.8"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 

--- a/sturdy/base/validator.py
+++ b/sturdy/base/validator.py
@@ -94,12 +94,6 @@ class BaseValidatorNeuron(BaseNeuron):
         # Init sync with the network. Updates the metagraph.
         await self.sync()
 
-        # Serve axon to enable external connections.
-        if not self.config.neuron.axon_off:
-            await self.serve_axon()
-        else:
-            bt.logging.warning("axon off, not serving ip to chain.")
-
         # Create asyncio event loop to manage async tasks.
         self.loop = asyncio.get_event_loop()
 

--- a/sturdy/utils/bt_alpha.py
+++ b/sturdy/utils/bt_alpha.py
@@ -6,7 +6,7 @@ from async_lru import alru_cache
 
 
 # Create tasks for fetching metagraph data
-@alru_cache(maxsize=512, ttl=60)
+@alru_cache(maxsize=512)
 async def fetch_metagraph(sub: bt.AsyncSubtensor, block: int, netuid: int) -> tuple[int, bt.MetagraphInfo]:
     try:
         metagraph = await sub.get_metagraph_info(netuid=netuid, block=block)
@@ -19,7 +19,7 @@ async def fetch_metagraph(sub: bt.AsyncSubtensor, block: int, netuid: int) -> tu
 
 
 # Create tasks for fetching dynamicinfo for a subnet
-@alru_cache(maxsize=512, ttl=60)
+@alru_cache(maxsize=512)
 async def fetch_dynamic_info(sub: bt.AsyncSubtensor, block: int, netuid: int) -> bt.DynamicInfo:
     try:
         dynamic_info = await sub.subnet(netuid=netuid, block=block)
@@ -32,7 +32,7 @@ async def fetch_dynamic_info(sub: bt.AsyncSubtensor, block: int, netuid: int) ->
 
 
 # Create tasks for fetching dividends of nominator from a validator and timestamps
-@alru_cache(maxsize=512, ttl=60)
+@alru_cache(maxsize=512)
 async def fetch_nominator_dividends(sub: bt.AsyncSubtensor, block: int, hotkey: str, netuid: int) -> tuple[int, int]:
     if netuid is None:
         return block, None, None
@@ -54,7 +54,7 @@ async def fetch_nominator_dividends(sub: bt.AsyncSubtensor, block: int, hotkey: 
         return block, None
 
 
-@alru_cache(maxsize=512, ttl=60)
+@alru_cache(maxsize=512)
 async def fetch_total_alpha_stake(sub: bt.AsyncSubtensor, block: int, hotkey: str, netuid: int) -> tuple[int, float]:
     try:
         uid = await sub.get_uid_for_hotkey_on_subnet(
@@ -72,7 +72,7 @@ async def fetch_total_alpha_stake(sub: bt.AsyncSubtensor, block: int, hotkey: st
         return block, 0
 
 
-@alru_cache(maxsize=512, ttl=60)
+@alru_cache(maxsize=512)
 async def get_vali_avg_apy(
     subtensor: bt.AsyncSubtensor,
     netuid: int,

--- a/sturdy/utils/config.py
+++ b/sturdy/utils/config.py
@@ -201,16 +201,6 @@ def add_validator_args(_cls, parser) -> None:
     )
 
     parser.add_argument(
-        "--neuron.axon_off",
-        "--axon_off",
-        action="store_true",
-        # Note: the validator needs to serve an Axon with their IP or they may
-        #   be blacklisted by the firewall of serving peers on the network.
-        help="Set this flag to not attempt to serve an Axon.",
-        default=False,
-    )
-
-    parser.add_argument(
         "--wandb.project_name",
         type=str,
         help="The name of the project where you are sending the new run.",


### PR DESCRIPTION
- validator axon no longer gets served - it's not necessary
- remove ttl parameters for alpha pool helpers
- updated docs for docker
