### PR TITLE
Performance Bonus Application Changes

### DIFF
--- a/sturdy/validator/reward.py
+++ b/sturdy/validator/reward.py
@@ -31,7 +31,7 @@ from sturdy.protocol import AllocationsDict, AllocInfo
 from sturdy.utils.bt_alpha import fetch_dynamic_info, get_vali_avg_apy
 from sturdy.utils.ethmath import wei_div
 from sturdy.utils.misc import get_scoring_period_length
-from sturdy.validator.apy_binning import calculate_bin_rewards, create_apy_bins
+from sturdy.validator.apy_binning import calculate_bin_rewards, create_apy_bins, sort_bins_by_processing_time
 from sturdy.validator.sql import get_db_connection, get_miner_responses, get_request_info
 
 
@@ -86,6 +86,7 @@ def _get_rewards(
 
     # Create APY-based bins
     apy_bins = create_apy_bins(apys)
+    apy_bins = sort_bins_by_processing_time(apy_bins, axon_times)
     bt.logging.debug(f"apy bins: {apy_bins}")
 
     # Calculate rewards based on bins and allocation similarity

--- a/tests/unit/validator/test_reward_helpers.py
+++ b/tests/unit/validator/test_reward_helpers.py
@@ -833,7 +833,8 @@ class TestBinRewardHelpers(unittest.IsolatedAsyncioTestCase):
     async def test_apply_top_performer_bonus(self) -> None:
         rewards = np.array([0.5, 0.8, 0.3, 1.0])
 
-        boosted_rewards = apply_top_performer_bonus(rewards)
+        top_indices = [2, 3]  # miner with reward index 2 was faster than 3
+        boosted_rewards = apply_top_performer_bonus(rewards, top_indices)
 
         # Check array type and length
         self.assertIsInstance(boosted_rewards, np.ndarray)
@@ -842,11 +843,8 @@ class TestBinRewardHelpers(unittest.IsolatedAsyncioTestCase):
         # Original array should not be modified
         self.assertFalse(np.array_equal(rewards, boosted_rewards))
 
-        # Get top performers in ascending order
-        top_indices = np.argsort(rewards)[-TOP_PERFORMERS_COUNT:]
-
         # Check that top performers got incrementally larger bonuses
-        for i, idx in enumerate(top_indices):
+        for i, idx in enumerate(top_indices[::-1]):
             expected_bonus = TOP_PERFORMERS_BONUS * (i + 1)
             self.assertEqual(boosted_rewards[idx], rewards[idx] * expected_bonus)
 


### PR DESCRIPTION
This PR modifies the performance bonus mechanism based on prediction difficulty:

Easy yield predictions: When yield prediction is straightforward, all miners achieve high accuracy and are placed in bin 0 with substantial rewards. In this scenario, the performance bonus is applied only to the 10 fastest miners to differentiate performance.

Difficult APY predictions: When predicting APY becomes more challenging, only the most accurate miner(s) qualify for bin 0 rewards. The performance bonus is then awarded based on prediction accuracy rather than speed.

This approach ensures that the bonus system adapts to varying prediction difficulty levels, rewarding speed during easy periods and accuracy during challenging periods.