### PR TITLE
Release/3.0.10

### DIFF
--- a/min_compute.yml
+++ b/min_compute.yml
@@ -10,7 +10,7 @@
 # Even then - storage isn't utilized very often - so disk performance won't really be a bottleneck vs, CPU, RAM, 
 # and network bandwidth.
 
-version: '3.0.9' # update this version key as needed, ideally should match your release version
+version: '3.0.10' # update this version key as needed, ideally should match your release version
 
 compute_spec:
 

--- a/sturdy/__init__.py
+++ b/sturdy/__init__.py
@@ -17,7 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the version of the template module.
-__version__ = "3.0.9"
+__version__ = "3.0.10"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 

--- a/sturdy/validator/apy_binning.py
+++ b/sturdy/validator/apy_binning.py
@@ -342,7 +342,8 @@ def calculate_bin_rewards(
     post_penalty_rewards = apply_penalties_to_rewards(rewards, penalties)
 
     # Apply performance bonus to the TOP_PERFORMERS_COUNT fastest miners in bin 0
-    top_miner_indices = bins[0][:TOP_PERFORMERS_COUNT]  # fastest miner is first
+    top_miner_uids = bins[0][:TOP_PERFORMERS_COUNT]  # fastest miner is first
+    top_miner_indices = [miner_uids.index(uid) for uid in top_miner_uids if uid in miner_uids]
     post_penalty_rewards = apply_top_performer_bonus(post_penalty_rewards, top_miner_indices)
 
     # Normalize rewards within each bin


### PR DESCRIPTION
This hotfix addresses indexing error when applying performance bonus:

```
[34m2025-06-06 01:46:00.812[39m | [1m[31m     ERROR      [39m[49m[0m | bittensor:loggingmachine.py:512 | Error in concurrent forward: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices
Traceback (most recent call last):
  File "/home/ubuntu/sturdy-subnet/sturdy/base/validator.py", line 150, in run_main_loop
    await self.concurrent_forward()
  File "/home/ubuntu/sturdy-subnet/sturdy/base/validator.py", line 217, in concurrent_forward
    await asyncio.gather(*coroutines)
  File "/home/ubuntu/sturdy-subnet/neurons/validator.py", line 87, in forward
    return await forward(self)
  File "/home/ubuntu/sturdy-subnet/sturdy/validator/forward.py", line 91, in forward
    axon_times, allocations = await query_and_score_miners(
  File "/home/ubuntu/sturdy-subnet/sturdy/validator/forward.py", line 302, in query_and_score_miners
    miner_uids, rewards = await get_rewards(self, active_alloc, data_provider)
  File "/home/ubuntu/sturdy-subnet/sturdy/validator/reward.py", line 384, in get_rewards
    return (miner_uids, _get_rewards(self, apys_and_allocations, assets_and_pools, miner_uids, axon_times))
  File "/home/ubuntu/sturdy-subnet/sturdy/validator/reward.py", line 93, in _get_rewards
    rewards, penalties = calculate_bin_rewards(apy_bins, apys_and_allocations, assets_and_pools, axon_times)
  File "/home/ubuntu/sturdy-subnet/sturdy/validator/apy_binning.py", line 346, in calculate_bin_rewards
    post_penalty_rewards = apply_top_performer_bonus(post_penalty_rewards, top_miner_indices)
  File "/home/ubuntu/sturdy-subnet/sturdy/validator/apy_binning.py", line 260, in apply_top_performer_bonus
    final_rewards[idx] *= TOP_PERFORMERS_BONUS * (i + 1)
IndexError: only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices

```