### PR TITLE
fix: relative diff based on current apy

### DIFF
--- a/min_compute.yml
+++ b/min_compute.yml
@@ -10,7 +10,7 @@
 # Even then - storage isn't utilized very often - so disk performance won't really be a bottleneck vs, CPU, RAM, 
 # and network bandwidth.
 
-version: '3.0.10' # update this version key as needed, ideally should match your release version
+version: '3.0.11' # update this version key as needed, ideally should match your release version
 
 compute_spec:
 

--- a/sturdy/__init__.py
+++ b/sturdy/__init__.py
@@ -17,7 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the version of the template module.
-__version__ = "3.0.10"
+__version__ = "3.0.11"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 


### PR DESCRIPTION
instead of:
```python
relative_diff = abs(apy - current_base_apy) / max(abs(current_base_apy), abs(apy), 1)
```
we calculate it as:
```python
relative_diff = float("inf") if apy == 0 else abs((current_base_apy - apy) / apy)
```
as we want to compare the relative difference in reference to the apy we are *currently* examining in the loop to help determine whether if it should be in a different bin vs. that of which contains `current_base_apy`.