### PR TITLE
fix: zero apy skip

### DIFF
--- a/min_compute.yml
+++ b/min_compute.yml
@@ -10,7 +10,7 @@
 # Even then - storage isn't utilized very often - so disk performance won't really be a bottleneck vs, CPU, RAM, 
 # and network bandwidth.
 
-version: '3.0.12' # update this version key as needed, ideally should match your release version
+version: '3.0.13' # update this version key as needed, ideally should match your release version
 
 compute_spec:
 

--- a/sturdy/__init__.py
+++ b/sturdy/__init__.py
@@ -17,7 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the version of the template module.
-__version__ = "3.0.12"
+__version__ = "3.0.13"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 

--- a/sturdy/validator/forward.py
+++ b/sturdy/validator/forward.py
@@ -299,7 +299,7 @@ async def query_and_score_miners(
 
         uids_to_delete.append(request_uid)
         # calculate rewards for previous active allocations
-        miner_uids, rewards = await get_rewards(self, active_alloc, data_provider)
+        miner_uids, rewards, should_update_scores = await get_rewards(self, active_alloc, data_provider)
         bt.logging.debug(f"miner rewards: {rewards}")
         bt.logging.debug(f"sim penalities: {self.similarity_penalties}")
 
@@ -309,7 +309,8 @@ async def query_and_score_miners(
 
         # update the moving average scores of the miners
         int_miner_uids = [int(uid) for uid in miner_uids]
-        self.update_scores(rewards, int_miner_uids)
+        if should_update_scores:
+            self.update_scores(rewards, int_miner_uids)
 
     # wipe these allocations from the db after scoring them
     if len(uids_to_delete) > 0:

--- a/sturdy/validator/reward.py
+++ b/sturdy/validator/reward.py
@@ -283,7 +283,7 @@ def filter_allocations(
 
 
 # TODO: we shouldn't need chain_data provider here, use self.pool_data_providers instead
-async def get_rewards(self, active_allocation, chain_data_provider: Web3 | bt.AsyncSubtensor) -> tuple[list, dict]:
+async def get_rewards(self, active_allocation, chain_data_provider: Web3 | bt.AsyncSubtensor) -> tuple[list, dict, bool]:
     # a dictionary, miner uids -> apy and allocations
     apys_and_allocations = {}
     miner_uids = []
@@ -380,5 +380,9 @@ async def get_rewards(self, active_allocation, chain_data_provider: Web3 | bt.As
     if len(miner_uids) < 1:
         return ([], {})
 
+    # if apys_and_allocations empty or apys are all zero, return miner uids, _get_rewards, and False
+    if not apys_and_allocations or all(value["apy"] == 0 for value in apys_and_allocations.values()):
+        bt.logging.warning("APYs are all zero or no APYs found, not updating miner scores")
+        return (miner_uids, _get_rewards(self, apys_and_allocations, assets_and_pools, miner_uids, axon_times), False)
     # get rewards given the apys and allocations(s) with _get_rewards (???)
-    return (miner_uids, _get_rewards(self, apys_and_allocations, assets_and_pools, miner_uids, axon_times))
+    return (miner_uids, _get_rewards(self, apys_and_allocations, assets_and_pools, miner_uids, axon_times), True)


### PR DESCRIPTION
- this fix makes it so that a validator will skip updating scores if all miners have zero apy.