### PR TITLE
fix calculation of alpha_lost and total_yield in case of delta<0

### DIFF
--- a/min_compute.yml
+++ b/min_compute.yml
@@ -10,7 +10,7 @@
 # Even then - storage isn't utilized very often - so disk performance won't really be a bottleneck vs, CPU, RAM, 
 # and network bandwidth.
 
-version: '3.0.14' # update this version key as needed, ideally should match your release version
+version: '3.0.15' # update this version key as needed, ideally should match your release version
 
 compute_spec:
 

--- a/sturdy/__init__.py
+++ b/sturdy/__init__.py
@@ -17,7 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the version of the template module.
-__version__ = "3.0.14"
+__version__ = "3.0.15"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 

--- a/sturdy/validator/reward.py
+++ b/sturdy/validator/reward.py
@@ -222,7 +222,7 @@ async def annualized_yield_pct(
                 total_yield += 0
         
     if tao_lost > 0:
-        total_yield -= yield_loss
+        total_yield -= tao_lost
 
     return wei_div(total_yield, initial_balance)
 

--- a/sturdy/validator/reward.py
+++ b/sturdy/validator/reward.py
@@ -171,7 +171,7 @@ async def annualized_yield_pct(
                         delta = initial_alloc - pool.current_amount
 
                         # alpha delta (in tao)
-                        alpha_delta_tao = delta / last_price
+                        alpha_delta_tao = delta / (last_price + 1)
 
                         # consider slippage
                         alpha_lost = 0


### PR DESCRIPTION
If delta < 0, tao_lost_bal results in a decrease in total assets.
So when calculate total_yield, consider this tao loss.