### PR TITLE
fix: dont refer to same synapse

### DIFF
--- a/min_compute.yml
+++ b/min_compute.yml
@@ -10,7 +10,7 @@
 # Even then - storage isn't utilized very often - so disk performance won't really be a bottleneck vs, CPU, RAM, 
 # and network bandwidth.
 
-version: '3.1.0' # update this version key as needed, ideally should match your release version
+version: '3.1.1' # update this version key as needed, ideally should match your release version
 
 compute_spec:
 

--- a/sturdy/__init__.py
+++ b/sturdy/__init__.py
@@ -17,7 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the version of the template module.
-__version__ = "3.1.0"
+__version__ = "3.1.1"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 

--- a/sturdy/base/validator.py
+++ b/sturdy/base/validator.py
@@ -336,7 +336,7 @@ class BaseValidatorNeuron(BaseNeuron):
         responses = [
             await self.dendrite.call(
                 target_axon=axon,
-                synapse=synapse,
+                synapse=synapse.model_copy(),
                 timeout=QUERY_TIMEOUT,
                 deserialize=False,
             )


### PR DESCRIPTION
using the same synapse object results in all the miners being considered as being a part of the same group (uniswap lp or pool allocator). this is bad. we now copy the synapse for each request instead of referring to the same one.


python moment `(._.)`