### PR TITLE
Fix timestamp calculation for one day ago

### DIFF
--- a/sturdy/utils/taofi_subgraph.py
+++ b/sturdy/utils/taofi_subgraph.py
@@ -9,10 +9,10 @@ TRANSPORT = AIOHTTPTransport(url=TAOFI_GQL_URL)
 GQL_CLIENT = Client(transport=TRANSPORT, fetch_schema_from_transport=True)
 
 
-async def get_uniswap_v3_pool_swaps(since: datetime, pool_address: str, client=GQL_CLIENT) -> dict:
+async def get_uniswap_v3_pool_swaps(since: int, pool_address: str, client=GQL_CLIENT) -> dict:
     # Convert datetime to UNIX timestamp (integer)
-    timestamp_unix = int(since.timestamp())
-    print(f"Fetching Uniswap V3 pool swaps since {since} (UNIX: {timestamp_unix}) for pool {pool_address}")
+    # timestamp_unix = int(since.timestamp())
+    print(f"Fetching Uniswap V3 pool swaps since (UNIX: {since}) for pool {pool_address}")
 
     # Create the GraphQL query string with the dynamic timestamp
     query = gql(
@@ -21,7 +21,7 @@ async def get_uniswap_v3_pool_swaps(since: datetime, pool_address: str, client=G
           swaps(
             where: {{
               pool: "{pool_address}",
-              timestamp_gt: {timestamp_unix}
+              timestamp_gt: {since}
             }},
             orderBy: timestamp,
             orderDirection: desc

--- a/sturdy/validator/reward.py
+++ b/sturdy/validator/reward.py
@@ -491,7 +491,7 @@ async def get_rewards_uniswap_v3_lp(
 
             # signature is valid, get swaps since the last 24 hours - timestamp is in utc
             # Get swaps from the last 24 hours
-            one_day_ago = datetime.utcnow() - timedelta(days=1)
+            one_day_ago = int(datetime.now().timestamp() - 24 * 60 * 60)
             swaps = await get_uniswap_v3_pool_swaps(since=one_day_ago, pool_address=request.pool_address)
 
             # calculate the fees earned by the miner for each swap


### PR DESCRIPTION
There was a bug in validator's code.
It's not getting correct timestamp.I think we need to use datetime.now().timestamp() - 86400 to get 1 day ago timestamp.
Timestamps are the same for the same time across all timezones.
![image](https://github.com/user-attachments/assets/717c5b21-b193-4568-82ba-3bef148f7343)
