### PR TITLE
Added validator hotkey to sign message

### DIFF
--- a/neurons/uniswap_lp.py
+++ b/neurons/uniswap_lp.py
@@ -15,6 +15,9 @@ async def uniswap_v3_lp_forward(
     synapse.token_ids = [33, 36, 49, 164]
 
     # sign the message with your wallet that owns the position(s)
+    if not synapse.message.startswith(synapse.dendrite.hotkey):
+        return synapse
+    
     message = encode_defunct(text=synapse.message)
     signed_msg: SignedMessage = self.test_w3.eth.account.sign_message(message, private_key=self.uniswap_pos_owner_key)
     synapse.signature = signed_msg.signature.hex()

--- a/sturdy/validator/forward.py
+++ b/sturdy/validator/forward.py
@@ -396,7 +396,7 @@ async def query_and_score_miners_uniswap_v3_lp(self) -> tuple[list, dict[int, fl
             token_0="0x9Dc08C6e2BF0F1eeD1E00670f80Df39145529F81",
             token_1="0xB833E8137FEDf80de7E908dc6fea43a029142F20",
             signature=None,
-            message=str(uuid.uuid4()).replace("-", ""),
+            message=self.wallet.hotkey + "-" + str(uuid.uuid4()).replace("-", ""),
         )
         for uid in uids_to_query
     ]


### PR DESCRIPTION
I added validator hotkey to sign message to prevent cheat.
Miners check if the sign message includes `synapse.dendrite.hotkey` to verify if it's from known sender.