### PR TITLE
fix: filter amounts from burn events

### DIFF
--- a/min_compute.yml
+++ b/min_compute.yml
@@ -10,7 +10,7 @@
 # Even then - storage isn't utilized very often - so disk performance won't really be a bottleneck vs, CPU, RAM, 
 # and network bandwidth.
 
-version: '4.0.6' # update this version key as needed, ideally should match your release version
+version: '4.0.7' # update this version key as needed, ideally should match your release version
 
 compute_spec:
 

--- a/sturdy/__init__.py
+++ b/sturdy/__init__.py
@@ -17,7 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the version of the template module.
-__version__ = "4.0.6"
+__version__ = "4.0.7"
 version_split = __version__.split(".")
 __spec_version__ = (1000 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))
 

--- a/sturdy/validator/reward.py
+++ b/sturdy/validator/reward.py
@@ -443,8 +443,12 @@ async def get_rewards_uniswap_v3_lp(
     try:
         current_block = await subtensor.get_current_block() - BLOCK_BUFFER
         one_day_ago = max(1, current_block - BLOCK_ONE_DAY_AGO)
+        one_day_block_timestamp = int((await subtensor.get_timestamp(block=one_day_ago)).timestamp())
         _, _, positions_growth = await calculate_fee_growth(
-            block_start=one_day_ago, block_end=current_block, web3_provider=web3_provider
+            block_start=one_day_ago,
+            block_end=current_block,
+            web3_provider=web3_provider,
+            subtract_burns_from_timestamp=one_day_block_timestamp,
         )
     except Exception as e:
         bt.logging.error(f"Error fetching information from Taofi subgraph: {e}")


### PR DESCRIPTION
When a position NFT gets burnt, the deposited liquidity associated with the position gets considered as uncollected fees: 

https://github.com/Uniswap/v3-core/blob/main/contracts/UniswapV3Pool.sol#L535-L540

This obviously shouldn't be considered as fees in our calculation, because it's really just the deposited liquidity for the position.