### PR TITLE
Fix burn rate exceeding 50% by excluding OWNER_UID from weight normalization

### DIFF
--- a/swap/base/validator.py
+++ b/swap/base/validator.py
@@ -231,10 +231,16 @@ class BaseValidatorNeuron(BaseNeuron):
                 "Scores contain NaN values. This may be due to a lack of responses from miners, or a bug in your reward \
                 functions."
             )
+            
+        # IMPORTANT: Zero out the owner UID score before normalization to prevent double-counting
+        scores_for_weights = self.scores.copy()
+        if OWNER_UID < len(scores_for_weights):
+            scores_for_weights[OWNER_UID] = 0.0
+            bt.logging.debug(f"Zeroed out score for OWNER_UID {OWNER_UID} before weight calculation")
 
         # Calculate the average reward for each uid across non-zero values.
         # Replace any NaN values with 0.
-        raw_weights = normalize_numpy(self.scores)
+        raw_weights = normalize_numpy(scores_for_weights)
 
         bt.logging.debug(f"raw_weights {raw_weights}")
         bt.logging.debug(f"raw_weight_uids {self.metagraph.uids}")


### PR DESCRIPTION
## Issue
Burn rate was exceeding 50% (according to burntensor it's 51.2%) because OWNER_UID (201) had a score that was included in weight normalization, causing the burn logic to over-allocate emissions to the owner.

<img width="1534" height="977" alt="image" src="https://github.com/user-attachments/assets/cb37f1fb-8587-4fc2-8f8b-36b2d35a0e8d" />

## Fix
Zero out OWNER_UID's score before normalizing weights to ensure clean 50/50 split between miners and burn address.

## Changes
- Modified `set_weights()` to copy scores and zero out OWNER_UID before `normalize_numpy()`
- Added debug logging for transparency

Contribution by Gittensor, learn more at https://gittensor.io/